### PR TITLE
fix: we shouldn't override env values from CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY . .
 RUN make
 
 EXPOSE 8000
-CMD ["build/arc", "--log", "stdout", "--env", "config/docker.env", "--plugins"]
+CMD ["build/arc", "--log", "stdout", "--plugins"]


### PR DESCRIPTION
When using this in a docker run context (or via K8S), the envs passed get overridden due to the CMD switch for `--env` present in this Dockerfile. The same can instead be achieved with a runtime command like `docker run --env-file=config/docker.env arc:local`

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Fixes runtime usage

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
