### PR TITLE
feat: expose billing variable from util.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 	}
 
 	router := mux.NewRouter().StrictSlash(true)
+	util.Billing = Billing
 
 	if Billing == "true" {
 		log.Println("You're running Arc with billing module enabled.")

--- a/util/util.go
+++ b/util/util.go
@@ -16,6 +16,9 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Global billing variable
+var Billing string
+
 // RandStr returns "node" field of a UUID.
 // See: https://tools.ietf.org/html/rfc4122#section-4.1.6
 func RandStr() string {


### PR DESCRIPTION
We need to do that because we have to access this variable in `arc-noss`, we can't import the global variables from `main.go` because of the circular dependency issue.