### PR TITLE
fix: allow sources check to pass if all is set

### DIFF
--- a/middleware/validate/sources.go
+++ b/middleware/validate/sources.go
@@ -34,7 +34,7 @@ func sources(h http.HandlerFunc) http.HandlerFunc {
 		if reqCredential == credential.Permission {
 			reqIP := iplookup.FromRequest(req)
 			if reqIP == "" {
-				msg := fmt.Sprintf(`failed to recognise request ip: "%s"`, reqIP)
+				msg := fmt.Sprintf(`failed to recognize request ip: "%s"`, reqIP)
 				util.WriteBackError(w, msg, http.StatusUnauthorized)
 				return
 			}
@@ -50,6 +50,10 @@ func sources(h http.HandlerFunc) http.HandlerFunc {
 
 			var validated bool
 			for _, source := range allowedSources {
+				if source == "0.0.0.0/0" {
+					validated = true
+					break
+				}
 				_, ipNet, err := net.ParseCIDR(source)
 				if err != nil {
 					log.Printf("%s: %v\n", logTag, err)


### PR DESCRIPTION
* handles IPv6 match case

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
It fixes a bug where an IPv6 based origin request would get rejected even though the API key is set to allow all sources.
