### PR TITLE
fix(auth): authentication bug with JWT

### DIFF
--- a/plugins/auth/dao.go
+++ b/plugins/auth/dao.go
@@ -289,7 +289,7 @@ func (es *elasticsearch) getRawRolePermission(ctx context.Context, role string) 
 	resp, err := es.client.Search().
 		Index(es.permissionIndex).
 		Type(es.permissionType).
-		Query(elastic.NewTermQuery("role", role)).
+		Query(elastic.NewTermQuery("role.keyword", role)).
 		Size(1).
 		FetchSource(true).
 		Do(ctx)

--- a/plugins/auth/handlers.go
+++ b/plugins/auth/handlers.go
@@ -22,11 +22,12 @@ func (a *Auth) savePublicKey(ctx context.Context, indexName string, record publi
 	if record.PublicKey != "" {
 		publicKeyBuf, err := util.DecodeBase64Key(record.PublicKey)
 		if err != nil {
-			log.Printf("%s: error indexing public key record", logTag)
+			log.Printf("%s: error indexing public key record, %s", logTag, err)
 			return false, err
 		}
 		jwtRsaPublicKey, err = jwt.ParseRSAPublicKeyFromPEM(publicKeyBuf)
 		if err != nil {
+			log.Printf("%s: error indexing public key record, %s", logTag, err)
 			return false, err
 		}
 	} else {

--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -25,7 +25,7 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		reqACL, err := acl.FromContext(ctx)
 		if err != nil {
 			log.Printf("%s: %v\n", logTag, err)
-			util.WriteBackError(w, "error classifyig request category", http.StatusInternalServerError)
+			util.WriteBackError(w, "error classifying request category", http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
* fix a bug where role name should be queried against .keyword field
* fix bug where JWT key from environment variables would override values
set in DB
* fix a crash where the role key isn't present in JWT claims
* format error messages related to username/role authentication for better comprehension