### PR TITLE
hotfix: add retry logic to ES proxy

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -219,6 +219,7 @@ func IntervalForRange(from, to string) (string, error) {
 	return fmt.Sprintf("%ds", int64(intervalInSecs)), nil
 }
 
+// DecodeBase64Key decodes a base64 input
 func DecodeBase64Key(encoded string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
@@ -228,4 +229,17 @@ func DecodeBase64Key(encoded string) ([]byte, error) {
 		return nil, err
 	}
 	return decoded, nil
+}
+
+// Retry is a general purpose retrier for a function call
+func Retry(numberRetries int, sleepInterval time.Duration, testFunc func() bool) {
+	executionPassed := false
+	executionCount := 0
+	for !executionPassed && executionCount < numberRetries {
+		executionPassed = testFunc()
+		if !executionPassed {
+			executionCount++
+			time.Sleep(sleepInterval)
+		}
+	}
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

This PR applies a retry check for ES proxy requests so they can be tried in case of failures related to TCP keep-alive (which are rare but happen).
