### PR TITLE
fix: consistent response for PATCH endpoints

### DIFF
--- a/plugins/permissions/handlers.go
+++ b/plugins/permissions/handlers.go
@@ -230,9 +230,9 @@ func (p *permissions) patchPermission() http.HandlerFunc {
 			}
 		}
 
-		raw, err := p.es.patchPermission(req.Context(), username, patch)
-		if err == nil {
-			util.WriteBackRaw(w, raw, http.StatusOK)
+		_, err2 := p.es.patchPermission(req.Context(), username, patch)
+		if err2 == nil {
+			util.WriteBackMessage(w, "Permission is updated successfully", http.StatusOK)
 			return
 		}
 

--- a/plugins/users/handlers.go
+++ b/plugins/users/handlers.go
@@ -210,9 +210,9 @@ func (u *Users) patchUser() http.HandlerFunc {
 			}
 		}
 
-		raw, err := u.es.patchUser(req.Context(), username, patch)
-		if err == nil {
-			util.WriteBackRaw(w, raw, http.StatusOK)
+		_, err2 := u.es.patchUser(req.Context(), username, patch)
+		if err2 == nil {
+			util.WriteBackMessage(w, "User is updated successfully", http.StatusOK)
 			return
 		}
 
@@ -281,9 +281,9 @@ func (u *Users) patchUserWithUsername() http.HandlerFunc {
 			}
 		}
 
-		raw, err := u.es.patchUser(req.Context(), username, patch)
-		if err == nil {
-			util.WriteBackRaw(w, raw, http.StatusOK)
+		_, err2 := u.es.patchUser(req.Context(), username, patch)
+		if err2 == nil {
+			util.WriteBackMessage(w, "User is updated successfully", http.StatusOK)
 			return
 		}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
This PR fixes the response returned by `PATCH` endpoints for `users` and `permissions` plugin, instead of returning the es response we should return a message with the status code which is consistent with other plugins.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
