### PR TITLE
feat: add default template for indices

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func main() {
 	// ES client instantiation
 	// ES v7 and v6 clients
 	util.NewClient()
+	util.SetDefaultIndexTemplate()
 	// map of specific plugins
 	sequencedPlugins := []string{"searchsettings.so", "rules.so", "functions.so", "analytics.so"}
 	sequencedPluginsByPath := make(map[string]string)

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"context"
+)
+
+// SetDefaultIndexTemplate to set default template for indexes
+func SetDefaultIndexTemplate() error {
+	response, err := GetClient7().IndexTemplateExists("default_temp").
+		Do(context.Background())
+	if err != nil || !response {
+		defaultSetting := `{"template" : "*", "settings" : {"number_of_shards" : 1, "max_ngram_diff" : 8, "max_shingle_diff" : 8}}`
+		_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this do / why do we need it?

* Checks if `default_temp` is set for all indexes. If not found sets the default template with correct ngram values so it doesn't throw an error while adding ngram analyzers.

`default_temp` is the name used for appbase clusters so keep it consistent, we are using the same name here.