### PR TITLE
fix: apply default index template for v7 only

### DIFF
--- a/util/es_template.go
+++ b/util/es_template.go
@@ -6,13 +6,16 @@ import (
 
 // SetDefaultIndexTemplate to set default template for indexes
 func SetDefaultIndexTemplate() error {
-	response, err := GetClient7().IndexTemplateExists("default_temp").
-		Do(context.Background())
-	if err != nil || !response {
-		defaultSetting := `{"template" : "*", "settings" : {"number_of_shards" : 1, "max_ngram_diff" : 8, "max_shingle_diff" : 8}}`
-		_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
-		if err != nil {
-			return err
+	version := GetVersion()
+	if version == 7 {
+		response, err := GetClient7().IndexTemplateExists("default_temp").
+			Do(context.Background())
+		if err != nil || !response {
+			defaultSetting := `{"template" : "*", "settings" : {"number_of_shards" : 1, "max_ngram_diff" : 8, "max_shingle_diff" : 8}}`
+			_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### What does this do / why do we need it?
Applies default template for v7 clusters only

