### PR TITLE
feat: replace index name with alias name

### DIFF
--- a/middleware/classify/util.go
+++ b/middleware/classify/util.go
@@ -1,7 +1,10 @@
 package classify
 
-// IndexAliasCache cache to store index alias map
+// IndexAliasCache cache to store index -> alias map
 var IndexAliasCache = make(map[string]string)
+
+// AliasIndexCache cache to store alias -> index map
+var AliasIndexCache = make(map[string]string)
 
 // GetIndexAliasCache get whole cache
 func GetIndexAliasCache() map[string]string {
@@ -21,4 +24,28 @@ func GetIndexAlias(index string) string {
 // SetIndexAlias set alias for specific index
 func SetIndexAlias(index, alias string) {
 	IndexAliasCache[index] = alias
+}
+
+// GetAliasIndex get index for specific alias
+func GetAliasIndex(alias string) string {
+	index, ok := AliasIndexCache[alias]
+	if !ok {
+		return ""
+	}
+	return index
+}
+
+// SetAliasIndex set index for specific alias
+func SetAliasIndex(alias, index string) {
+	AliasIndexCache[alias] = index
+}
+
+// SetAliasIndexCache set the whole cache
+func SetAliasIndexCache(data map[string]string) {
+	AliasIndexCache = data
+}
+
+// GetAliasIndexCache get the whole cache
+func GetAliasIndexCache() map[string]string {
+	return AliasIndexCache
 }

--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -293,6 +293,7 @@ func setAlias(ctx context.Context, indexName string, aliases ...string) error {
 
 	// We only have one alias per index.
 	classify.SetIndexAlias(indexName, aliases[0])
+	classify.SetAliasIndex(aliases[0], indexName)
 	return nil
 }
 
@@ -353,4 +354,20 @@ func getAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 	}
 
 	return indicesList, nil
+}
+
+func getAliasIndexMap(ctx context.Context) (map[string]string, error) {
+	var res = make(map[string]string)
+	aliases, err := util.GetClient7().CatAliases().
+		Pretty(true).
+		Do(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	for _, alias := range aliases {
+		res[alias.Alias] = alias.Index
+	}
+
+	return res, nil
 }

--- a/plugins/reindexer/reindexer.go
+++ b/plugins/reindexer/reindexer.go
@@ -33,6 +33,7 @@ func (rx *reindexer) Name() string {
 
 func (rx *reindexer) InitFunc() error {
 	InitIndexAliasCache()
+	InitAliasIndexCache()
 	return nil
 }
 

--- a/plugins/reindexer/util.go
+++ b/plugins/reindexer/util.go
@@ -59,12 +59,20 @@ func reindexedName(indexName string) (string, error) {
 // InitIndexAliasCache to set cache on arc initialization
 func InitIndexAliasCache() {
 	ctx := context.Background()
-	aliasedIndexes, _ := getAliasedIndices(ctx)
+	indexAlias, _ := getAliasedIndices(ctx)
 
-	for _, aliasIndex := range aliasedIndexes {
+	for _, aliasIndex := range indexAlias {
 		if aliasIndex.Alias != "" {
 			classify.SetIndexAlias(aliasIndex.Index, aliasIndex.Alias)
 		}
 	}
-	log.Println(logTag, "=> Alias Index Cache", classify.GetIndexAliasCache())
+	log.Println(logTag, "=> Index Alias Cache", classify.GetIndexAliasCache())
+}
+
+// InitAliasIndexCache to set alias -> index cache on initialization
+func InitAliasIndexCache() {
+	ctx := context.Background()
+	aliasIndexMap, _ := getAliasIndexMap(ctx)
+	classify.SetAliasIndexCache(aliasIndexMap)
+	log.Println(logTag, "=> Alias Index Cache", classify.GetAliasIndexCache())
 }


### PR DESCRIPTION
### What does this do / why do we need it?

* Update elasticsearch middleware to not return if permissions failed, as it also needs to process response.
* Replace `index` name with alias name in response
* Add `alias` -> `index` cache to find index name in response if only alias is available in url
