### PR TITLE
fix: use error log instead of fatal in billing

### DIFF
--- a/util/billing.go
+++ b/util/billing.go
@@ -277,7 +277,7 @@ func SetClusterPlan() {
 	}
 	_, err := getClusterPlan(clusterID)
 	if err != nil {
-		log.Fatalln("Unable to fetch the cluster plan. Please make sure that you're using a valid CLUSTER_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.", err)
+		log.Errorln("Unable to fetch the cluster plan. Please make sure that you're using a valid CLUSTER_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.", err)
 		return
 	}
 }
@@ -363,7 +363,7 @@ func ReportUsage() {
 
 	result, err := getArcInstance(arcID)
 	if err != nil {
-		log.Fatalln("Unable to fetch the arc instance. Please make sure that you're using a valid ARC_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.")
+		log.Errorln("Unable to fetch the arc instance. Please make sure that you're using a valid ARC_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.")
 		return
 	}
 
@@ -412,7 +412,7 @@ func ReportHostedArcUsage() {
 	// getArcClusterInstance(clusterId)
 	result, err := getArcClusterInstance(clusterID)
 	if err != nil {
-		log.Fatalln("Unable to fetch the arc instance. Please make sure that you're using a valid CLUSTER_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.", err)
+		log.Errorln("Unable to fetch the arc instance. Please make sure that you're using a valid CLUSTER_ID. If the issue persists please contact support@appbase.io with your ARC_ID or registered e-mail address.", err)
 		return
 	}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
Recently we faced an issue when our ACCAPI went down all our arc pods went down. We tried simulating the situation on local
https://www.dropbox.com/s/jkgck1nat28n5n8/Screenshot%202020-03-24%2008.23.28.png?dl=0
It is returned from here
https://github.com/appbaseio/arc/blob/dev/util/billing.go#L280
Because of `log.Fatalln` also calls `os.Exit(1)`
https://golang.org/pkg/log/#Fatalln

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?
This PR will fix the issue by replacing the `Fatal` logs to the `Error` when there is a failure in ACC_API.
<!--

fixes #
fixes #

-->
