### PR TITLE
feat: add template for searchable fields

### DIFF
--- a/util/es_template.go
+++ b/util/es_template.go
@@ -2,124 +2,152 @@ package util
 
 import (
 	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // SetDefaultIndexTemplate to set default template for indexes
 func SetDefaultIndexTemplate() error {
+
+	analyzers := `{
+		"analyzer": {
+			"universal": {
+				"tokenizer": "standard",
+				"filter": [
+					"universal_stop"
+				]
+			},
+			"autosuggest_analyzer": {
+				"filter": [
+					"lowercase",
+					"asciifolding",
+					"autosuggest_filter"
+				],
+				"tokenizer": "standard",
+				"type": "custom"
+			},
+			"ngram_analyzer": {
+				"filter": [
+					"lowercase",
+					"asciifolding",
+					"ngram_filter"
+				],
+				"tokenizer": "standard",
+				"type": "custom"
+			},
+			"synonyms": {
+				"tokenizer": "standard",
+				"filter": [
+					"synonym_graph",
+					"lowercase"
+				]
+			}
+		},
+		"filter": {
+			"synonym_graph": {
+				"type": "synonym_graph",
+				"synonyms": []
+			},
+			"universal_stop": {
+				"type": "stop",
+				"stopwords": "_english_"
+			},
+			"autosuggest_filter": {
+				"max_gram": "20",
+				"min_gram": "1",
+				"token_chars": [
+					"letter",
+					"digit",
+					"punctuation",
+					"symbol"
+				],
+				"type": "edge_ngram"
+			},
+			"ngram_filter": {
+				"max_gram": "9",
+				"min_gram": "2",
+				"token_chars": [
+					"letter",
+					"digit",
+					"punctuation",
+					"symbol"
+				],
+				"type": "ngram"
+			}
+		}
+	}`
+
+	mappings := `{
+		"dynamic_templates": [{
+			"strings": {
+				"match_mapping_type": "string",
+				"mapping": {
+					"type": "text",
+					"analyzer": "standard",
+					"fields": {
+						"autosuggest": {
+							"type": "text",
+							"analyzer": "autosuggest_analyzer",
+							"search_analyzer": "simple"
+						},
+						"keyword": {
+							"type": "keyword",
+							"ignore_above": 256
+						},
+						"search": {
+							"type": "text",
+							"analyzer": "ngram_analyzer",
+							"search_analyzer": "simple"
+						},
+						"synonyms": {
+							"type": "text",
+							"analyzer": "synonym"
+						},
+						"lang": {
+							"type": "text",
+							"analyzer": "universal"
+						}
+					}
+				}
+			}
+		}],
+		"dynamic": true
+	}`
+
 	version := GetVersion()
 	if version == 7 {
-		defaultSetting := `{
+		defaultSetting := fmt.Sprintf(`{
 			"template": "*",
 			"settings": {
 				"number_of_shards": 1,
 				"max_ngram_diff": 8,
 				"max_shingle_diff": 8,
-				"analysis": {
-					"analyzer": {
-						"universal": {
-							"tokenizer": "standard",
-							"filter": [
-								"universal_stop"
-							]
-						},
-						"autosuggest_analyzer": {
-							"filter": [
-								"lowercase",
-								"asciifolding",
-								"autosuggest_filter"
-							],
-							"tokenizer": "standard",
-							"type": "custom"
-						},
-						"ngram_analyzer": {
-							"filter": [
-								"lowercase",
-								"asciifolding",
-								"ngram_filter"
-							],
-							"tokenizer": "standard",
-							"type": "custom"
-						},
-						"synonym": {
-							"tokenizer": "standard",
-							"filter": [
-								"synonym_graph"
-							]
-						}
-					},
-					"filter": {
-						"synonym_graph": {
-							"type": "synonym_graph",
-							"synonyms": []
-						},
-						"universal_stop": {
-							"type": "stop",
-							"stopwords": "_english_"
-						},
-						"autosuggest_filter": {
-							"max_gram": "20",
-							"min_gram": "1",
-							"token_chars": [
-								"letter",
-								"digit",
-								"punctuation",
-								"symbol"
-							],
-							"type": "edge_ngram"
-						},
-						"ngram_filter": {
-							"max_gram": "9",
-							"min_gram": "2",
-							"token_chars": [
-								"letter",
-								"digit",
-								"punctuation",
-								"symbol"
-							],
-							"type": "ngram"
-						}
-					}
-				}
+				"analysis": %s 
 			},
-			"mappings": {
-				"dynamic_templates": [{
-					"strings": {
-						"match_mapping_type": "string",
-						"mapping": {
-							"type": "text",
-							"analyzer": "standard",
-							"fields": {
-								"autosuggest": {
-									"type": "text",
-									"analyzer": "autosuggest_analyzer",
-									"search_analyzer": "simple"
-								},
-								"keyword": {
-									"type": "keyword",
-									"ignore_above": 256
-								},
-								"search": {
-									"type": "text",
-									"analyzer": "ngram_analyzer",
-									"search_analyzer": "simple"
-								},
-								"synonym": {
-									"type": "text",
-									"analyzer": "synonym"
-								},
-								"lang": {
-									"type": "text",
-									"analyzer": "universal"
-								}
-							}
-						}
-					}
-				}],
-				"dynamic": true
-			}
-		}`
+			"mappings": %s
+		}`, analyzers, mappings)
 		_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
 		if err != nil {
+			log.Errorln("[SET TEMPLATE ERROR V7]", ": ", err)
+			return err
+		}
+	}
+
+	if version == 6 {
+		defaultSetting := fmt.Sprintf(`{
+			"template": "*",
+			"settings": {
+				"number_of_shards": 1,
+				"analysis": %s 
+			},
+			"mappings": {
+				"_doc": %s
+			}
+		}`, analyzers, mappings)
+		_, err := GetClient6().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
+		if err != nil {
+			log.Errorln("[SET TEMPLATE ERROR V6]", ": ", err)
 			return err
 		}
 	}

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -8,14 +8,93 @@ import (
 func SetDefaultIndexTemplate() error {
 	version := GetVersion()
 	if version == 7 {
-		response, err := GetClient7().IndexTemplateExists("default_temp").
-			Do(context.Background())
-		if err != nil || !response {
-			defaultSetting := `{"template" : "*", "settings" : {"number_of_shards" : 1, "max_ngram_diff" : 8, "max_shingle_diff" : 8}}`
-			_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
-			if err != nil {
-				return err
+		defaultSetting := `{
+			"template": "*",
+			"settings": {
+			"number_of_shards": 1,
+			"max_ngram_diff": 8,
+			"max_shingle_diff": 8,
+			"analysis": {
+				"analyzer": {
+				"autosuggest_analyzer": {
+					"filter": [
+					"lowercase",
+					"asciifolding",
+					"autosuggest_filter"
+					],
+					"tokenizer": "standard",
+					"type": "custom"
+				},
+				"ngram_analyzer": {
+					"filter": [
+					"lowercase",
+					"asciifolding",
+					"ngram_filter"
+					],
+					"tokenizer": "standard",
+					"type": "custom"
+				}
+				},
+				"filter": {
+				"autosuggest_filter": {
+					"max_gram": "20",
+					"min_gram": "1",
+					"token_chars": [
+					"letter",
+					"digit",
+					"punctuation",
+					"symbol"
+					],
+					"type": "edge_ngram"
+				},
+				"ngram_filter": {
+					"max_gram": "9",
+					"min_gram": "2",
+					"token_chars": [
+					"letter",
+					"digit",
+					"punctuation",
+					"symbol"
+					],
+					"type": "ngram"
+				}
+				}
 			}
+			},
+			"mappings": {
+			"dynamic_templates": [
+				{
+				"strings": {
+					"match_mapping_type": "string",
+					"mapping": {
+					"type": "text",
+					"fields": {
+						"autosuggest": {
+						"type": "text",
+						"analyzer": "autosuggest_analyzer",
+						"search_analyzer": "simple"
+						},
+						"keyword": {
+						"type": "keyword",
+						"ignore_above": 256
+						},
+						"search": {
+						"type": "text",
+						"analyzer": "ngram_analyzer",
+						"search_analyzer": "simple"
+						}
+					},
+					"analyzer": "standard"
+					}
+				}
+				}
+			],
+			"dynamic": true
+			}
+		}`
+		_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -11,85 +11,111 @@ func SetDefaultIndexTemplate() error {
 		defaultSetting := `{
 			"template": "*",
 			"settings": {
-			"number_of_shards": 1,
-			"max_ngram_diff": 8,
-			"max_shingle_diff": 8,
-			"analysis": {
-				"analyzer": {
-				"autosuggest_analyzer": {
-					"filter": [
-					"lowercase",
-					"asciifolding",
-					"autosuggest_filter"
-					],
-					"tokenizer": "standard",
-					"type": "custom"
-				},
-				"ngram_analyzer": {
-					"filter": [
-					"lowercase",
-					"asciifolding",
-					"ngram_filter"
-					],
-					"tokenizer": "standard",
-					"type": "custom"
-				}
-				},
-				"filter": {
-				"autosuggest_filter": {
-					"max_gram": "20",
-					"min_gram": "1",
-					"token_chars": [
-					"letter",
-					"digit",
-					"punctuation",
-					"symbol"
-					],
-					"type": "edge_ngram"
-				},
-				"ngram_filter": {
-					"max_gram": "9",
-					"min_gram": "2",
-					"token_chars": [
-					"letter",
-					"digit",
-					"punctuation",
-					"symbol"
-					],
-					"type": "ngram"
-				}
-				}
-			}
-			},
-			"mappings": {
-			"dynamic_templates": [
-				{
-				"strings": {
-					"match_mapping_type": "string",
-					"mapping": {
-					"type": "text",
-					"fields": {
-						"autosuggest": {
-						"type": "text",
-						"analyzer": "autosuggest_analyzer",
-						"search_analyzer": "simple"
+				"number_of_shards": 1,
+				"max_ngram_diff": 8,
+				"max_shingle_diff": 8,
+				"analysis": {
+					"analyzer": {
+						"universal": {
+							"tokenizer": "standard",
+							"filter": [
+								"universal_stop"
+							]
 						},
-						"keyword": {
-						"type": "keyword",
-						"ignore_above": 256
+						"autosuggest_analyzer": {
+							"filter": [
+								"lowercase",
+								"asciifolding",
+								"autosuggest_filter"
+							],
+							"tokenizer": "standard",
+							"type": "custom"
 						},
-						"search": {
-						"type": "text",
-						"analyzer": "ngram_analyzer",
-						"search_analyzer": "simple"
+						"ngram_analyzer": {
+							"filter": [
+								"lowercase",
+								"asciifolding",
+								"ngram_filter"
+							],
+							"tokenizer": "standard",
+							"type": "custom"
+						},
+						"synonym": {
+							"tokenizer": "standard",
+							"filter": [
+								"synonym_graph"
+							]
 						}
 					},
-					"analyzer": "standard"
+					"filter": {
+						"synonym_graph": {
+							"type": "synonym_graph",
+							"synonyms": []
+						},
+						"universal_stop": {
+							"type": "stop",
+							"stopwords": "_english_"
+						},
+						"autosuggest_filter": {
+							"max_gram": "20",
+							"min_gram": "1",
+							"token_chars": [
+								"letter",
+								"digit",
+								"punctuation",
+								"symbol"
+							],
+							"type": "edge_ngram"
+						},
+						"ngram_filter": {
+							"max_gram": "9",
+							"min_gram": "2",
+							"token_chars": [
+								"letter",
+								"digit",
+								"punctuation",
+								"symbol"
+							],
+							"type": "ngram"
+						}
 					}
 				}
-				}
-			],
-			"dynamic": true
+			},
+			"mappings": {
+				"dynamic_templates": [{
+					"strings": {
+						"match_mapping_type": "string",
+						"mapping": {
+							"type": "text",
+							"analyzer": "standard",
+							"fields": {
+								"autosuggest": {
+									"type": "text",
+									"analyzer": "autosuggest_analyzer",
+									"search_analyzer": "simple"
+								},
+								"keyword": {
+									"type": "keyword",
+									"ignore_above": 256
+								},
+								"search": {
+									"type": "text",
+									"analyzer": "ngram_analyzer",
+									"search_analyzer": "simple"
+								},
+								"synonym": {
+									"type": "text",
+									"analyzer": "synonym"
+								},
+								"lang": {
+									"type": "text",
+									"analyzer": "universal"
+								}
+							}
+						}
+					}
+				}],
+				"dynamic": true
 			}
 		}`
 		_, err := GetClient7().IndexPutTemplate("default_temp").BodyString(defaultSetting).Do(context.Background())


### PR DESCRIPTION
### What does this do / why do we need it?

* Add mappings & settings in the default v7 template for searchable fields. i.e. it will add `.search`, `.autosuggest` and `.keyword` fields
* Remove check if the template exists. This will help us in updating template any time we want and ES also allows updating template with the same name.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
