### PR TITLE
feat: build suggestions plugin after analytics

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func main() {
 	util.NewClient()
 	util.SetDefaultIndexTemplate()
 	// map of specific plugins
-	sequencedPlugins := []string{"searchrelevancy.so", "rules.so", "functions.so", "analytics.so"}
+	sequencedPlugins := []string{"searchrelevancy.so", "rules.so", "functions.so", "analytics.so", "suggestions.so"}
 	sequencedPluginsByPath := make(map[string]string)
 
 	var elasticSearchPath, reactiveSearchPath string


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?
We were loading the `suggestions` plugin before the `analytics` plugin, `suggestions` plugin uses the analytics index to generate the suggestions which throw the error initially when `.analytics` index is not present.

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
