### PR TITLE
fix: add rollover for logs index

### DIFF
--- a/middleware/classify/util.go
+++ b/middleware/classify/util.go
@@ -49,3 +49,8 @@ func SetAliasIndexCache(data map[string]string) {
 func GetAliasIndexCache() map[string]string {
 	return AliasIndexCache
 }
+
+// RemoveFromIndexAliasCache get the whole cache
+func RemoveFromIndexAliasCache(indexName string) {
+	delete(IndexAliasCache, indexName)
+}

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -80,7 +80,7 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while creating a rollover service \"%s\" %v", alias, err)
 	}
-	log.Println(logTag, ": rollover res", &rolloverService.Acknowledged)
+	log.Println(logTag, ": rollover svc created ", rolloverService.Acknowledged)
 	return es, nil
 }
 

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -48,6 +48,7 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 	settings := fmt.Sprintf(config, alias, nodes, nodes-1)
 	// Meta index doesn't exist, create one
 	indexName := alias + `-000001`
+	// this works for ES6 client as well
 	_, err = util.GetClient7().CreateIndex(indexName).
 		Body(settings).
 		Do(ctx)

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -134,7 +134,5 @@ func (es *elasticsearch) rolloverIndex(alias string) {
 		classify.RemoveFromIndexAliasCache(rolloverService.OldIndex)
 		classify.SetIndexAlias(rolloverService.NewIndex, alias)
 		classify.SetAliasIndex(alias, rolloverService.NewIndex)
-
-		log.Println("=> new cache", classify.GetIndexAliasCache(), classify.GetAliasIndexCache())
 	}
 }

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -16,6 +16,11 @@ const (
 	envLogsEsIndex     = "LOGS_ES_INDEX"
 	config             = `
 	{
+	  "aliases": {
+		"%s": {
+		  "is_write_index": true
+	    }
+	  },
 	  "settings": {
 	    "number_of_shards": %d,
 	    "number_of_replicas": %d
@@ -69,7 +74,7 @@ func (l *Logs) InitFunc() error {
 
 	// init cron job
 	cronjob := cron.New()
-	cronjob.AddFunc("@midnight", func() { l.es.rolloverIndex(indexName) })
+	cronjob.AddFunc("@midnight", func() { l.es.rolloverIndexJob(indexName) })
 	cronjob.Start()
 
 	return nil

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -23,7 +23,7 @@ const (
 	}`
 	rolloverConfig = `{
 		"max_age":  "7d",
-		"max_docs": 10,
+		"max_docs": 10000,
 		"max_size": "1gb"
 	}`
 )
@@ -69,7 +69,7 @@ func (l *Logs) InitFunc() error {
 
 	// init cron job
 	cronjob := cron.New()
-	cronjob.AddFunc("@every 10s", func() { l.es.rolloverIndex(indexName) })
+	cronjob.AddFunc("@midnight", func() { l.es.rolloverIndex(indexName) })
 	cronjob.Start()
 
 	return nil

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -21,6 +21,11 @@ const (
 	    "number_of_replicas": %d
 	  }
 	}`
+	rolloverConfig = `{
+		"max_age":  "7d",
+		"max_docs": 10,
+		"max_size": "1gb"
+	}`
 )
 
 var (
@@ -64,7 +69,7 @@ func (l *Logs) InitFunc() error {
 
 	// init cron job
 	cronjob := cron.New()
-	cronjob.AddFunc("@midnight", l.es.rolloverIndex)
+	cronjob.AddFunc("@every 10s", func() { l.es.rolloverIndex(indexName) })
 	cronjob.Start()
 
 	return nil

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/appbaseio/arc/middleware"
 	"github.com/appbaseio/arc/plugins"
+	"github.com/robfig/cron"
 )
 
 const (
@@ -60,6 +61,11 @@ func (l *Logs) InitFunc() error {
 	if err != nil {
 		return err
 	}
+
+	// init cron job
+	cronjob := cron.New()
+	cronjob.AddFunc("@midnight", l.es.rolloverIndex)
+	cronjob.Start()
 
 	return nil
 }

--- a/plugins/logs/service.go
+++ b/plugins/logs/service.go
@@ -5,5 +5,5 @@ import "context"
 type logsService interface {
 	getRawLogs(ctx context.Context, from, size, filter string, indices ...string) ([]byte, error)
 	indexRecord(ctx context.Context, r record)
-	rolloverIndex()
+	rolloverIndex(alias string)
 }

--- a/plugins/logs/service.go
+++ b/plugins/logs/service.go
@@ -5,5 +5,5 @@ import "context"
 type logsService interface {
 	getRawLogs(ctx context.Context, from, size, filter string, indices ...string) ([]byte, error)
 	indexRecord(ctx context.Context, r record)
-	rolloverIndex(alias string)
+	rolloverIndexJob(alias string)
 }

--- a/plugins/logs/service.go
+++ b/plugins/logs/service.go
@@ -5,4 +5,5 @@ import "context"
 type logsService interface {
 	getRawLogs(ctx context.Context, from, size, filter string, indices ...string) ([]byte, error)
 	indexRecord(ctx context.Context, r record)
+	rolloverIndex()
 }

--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -358,13 +358,20 @@ func getAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 		}
 		var alias string
 		regex := ".*reindexed_[0-9]+"
-		r, _ := regexp.Compile(regex)
+		rolloverPatter := ".*-[0-9]+"
+		rolloverRegex, _ := regexp.Compile(rolloverPatter)
+		indexRegex, _ := regexp.Compile(regex)
 
 		for _, row := range aliases {
-			if row.Index == index.Index && r.MatchString(index.Index) {
+			// match the alias for rollover index
+			if row.Index[:1] == "." && row.Index == index.Index && rolloverRegex.MatchString(index.Index) {
+				alias = row.Alias
+				break
+			} else if row.Index == index.Index && indexRegex.MatchString(index.Index) {
 				alias = row.Alias
 				break
 			}
+
 		}
 		if err == nil && alias != "" {
 			indexStruct.Alias = alias


### PR DESCRIPTION
#### What does this do / why do we need it?
* Add rollover logic for `.logs` index.
This is required because of `.logs` started occupying more and more space on clusters and was putting ES instance down.

#### What should your reviewer look out for in this PR?
* Logic to add an alias with `.logs-000001` as base index for logs.
https://github.com/appbaseio/arc/blob/fix/logs-rollover/plugins/logs/dao.go#L24
* Cron job which deletes older index every midnight
* Logic for system indices alias in `/_aliasedindices` which is used by FE
https://github.com/appbaseio/arc/blob/fix/logs-rollover/plugins/reindexer/dao.go#L362

#### How have you tested this PR
https://www.loom.com/share/4e2dbb69264647bdb3ff4dd9cf255093

### Side effects
* Need to delete / migrate older `.logs` index to `.logs-000001`