### PR TITLE
fix: add rollover config based on plan

### DIFF
--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -20,6 +20,7 @@ type elasticsearch struct {
 }
 
 func initPlugin(alias, config string) (*elasticsearch, error) {
+
 	ctx := context.Background()
 
 	var es = &elasticsearch{alias}
@@ -62,7 +63,12 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 	classify.SetAliasIndex(alias, indexName)
 
 	rolloverConditions := make(map[string]interface{})
-	json.Unmarshal([]byte(rolloverConfig), &rolloverConditions)
+
+	rolloverConfiguration := fmt.Sprintf(rolloverConfig, "7d", 10000, "1gb")
+	if util.IsProductionPlan() {
+		rolloverConfiguration = fmt.Sprintf(rolloverConfig, "30d", 1000000, "5gb")
+	}
+	json.Unmarshal([]byte(rolloverConfiguration), &rolloverConditions)
 	rolloverService, err := es7.NewIndicesRolloverService(util.GetClient7()).
 		Alias(alias).
 		Conditions(rolloverConditions).
@@ -108,7 +114,11 @@ func (es *elasticsearch) getRawLogs(ctx context.Context, from, size, filter stri
 func (es *elasticsearch) rolloverIndexJob(alias string) {
 	ctx := context.Background()
 	rolloverConditions := make(map[string]interface{})
-	json.Unmarshal([]byte(rolloverConfig), &rolloverConditions)
+	rolloverConfiguration := fmt.Sprintf(rolloverConfig, "7d", 10000, "1gb")
+	if util.IsProductionPlan() {
+		rolloverConfiguration = fmt.Sprintf(rolloverConfig, "30d", 1000000, "5gb")
+	}
+	json.Unmarshal([]byte(rolloverConfiguration), &rolloverConditions)
 	rolloverService, err := es7.NewIndicesRolloverService(util.GetClient7()).
 		Alias(alias).
 		Conditions(rolloverConditions).

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -27,9 +27,9 @@ const (
 	  }
 	}`
 	rolloverConfig = `{
-		"max_age":  "7d",
-		"max_docs": 10000,
-		"max_size": "1gb"
+		"max_age":  "%s",
+		"max_docs": %d,
+		"max_size": "%s"
 	}`
 )
 

--- a/util/plans.go
+++ b/util/plans.go
@@ -170,3 +170,17 @@ func ValidatePlans(validPlans []Plan, byPassValidation bool) bool {
 	}
 	return false
 }
+
+// IsProductionPlan validates if the user's plan is a production plan
+func IsProductionPlan() bool {
+	switch GetTier().String() {
+	case ArcEnterprise.String(),
+		ProductionFirst2019.String(),
+		ProductionSecond2019.String(),
+		ProductionThird2019.String(),
+		ProductionFourth2019.String():
+		return true
+	default:
+		return false
+	}
+}

--- a/util/plans.go
+++ b/util/plans.go
@@ -174,11 +174,7 @@ func ValidatePlans(validPlans []Plan, byPassValidation bool) bool {
 // IsProductionPlan validates if the user's plan is a production plan
 func IsProductionPlan() bool {
 	switch GetTier().String() {
-	case ArcEnterprise.String(),
-		ProductionFirst2019.String(),
-		ProductionSecond2019.String(),
-		ProductionThird2019.String(),
-		ProductionFourth2019.String():
+	case ArcEnterprise.String(), ProductionFirst2019.String(), ProductionSecond2019.String(), ProductionThird2019.String(), ProductionFourth2019.String():
 		return true
 	default:
 		return false


### PR DESCRIPTION
#### What does this do / why do we need it?

* This PR adds different rollover configuration for `.logs` based on plan
* For production plans rollover configs are

```
max_age: 30days
max_docs: 1000000
max_size: 5gb
```

#### What should your reviewer look out for in this PR?
* Are the configuration correct for production plans
