### PR TITLE
fix: original index deletion on clone

### DIFF
--- a/plugins/reindexer/actions.go
+++ b/plugins/reindexer/actions.go
@@ -11,3 +11,14 @@ const (
 func (o Action) String() string {
 	return [...]string{"mappings", "settings", "data"}[o]
 }
+
+type ReIndexOperation int
+
+const (
+	ReIndexWithDelete ReIndexOperation = iota
+	ReindexWithClone
+)
+
+func (o ReIndexOperation) String() string {
+	return [...]string{"reindex_with_delete", "reindex_with_clone"}[o]
+}

--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -15,7 +15,7 @@ import (
 	es7 "github.com/olivere/elastic/v7"
 )
 
-func postReIndex(ctx context.Context, sourceIndex, newIndexName string) error {
+func postReIndex(ctx context.Context, sourceIndex, newIndexName string, delOldIndex bool) error {
 	// Fetch all the aliases of old index
 	alias, err := aliasesOf(ctx, sourceIndex)
 
@@ -31,16 +31,17 @@ func postReIndex(ctx context.Context, sourceIndex, newIndexName string) error {
 	}
 
 	// Delete old index
-	err = deleteIndex(ctx, sourceIndex)
-	if err != nil {
-		return errors.New(`error deleting source index ` + sourceIndex + "\n" + err.Error())
+	if delOldIndex {
+		err = deleteIndex(ctx, sourceIndex)
+		if err != nil {
+			return errors.New(`error deleting source index ` + sourceIndex + "\n" + err.Error())
+		}
+		// Set aliases of old index to the new index.
+		err = setAlias(ctx, newIndexName, aliases...)
+		if err != nil {
+			return errors.New(`error setting alias for ` + newIndexName + "\n" + err.Error())
+		}
 	}
-	// Set aliases of old index to the new index.
-	err = setAlias(ctx, newIndexName, aliases...)
-	if err != nil {
-		return errors.New(`error setting alias for ` + newIndexName + "\n" + err.Error())
-	}
-
 	return nil
 }
 
@@ -110,7 +111,8 @@ func reindex(ctx context.Context, sourceIndex string, config *reindexConfig, wai
 		body["settings"] = config.Settings
 	}
 	newIndexName := destinationIndex
-	if destinationIndex == "" {
+	isClone := destinationIndex != ""
+	if !isClone {
 		newIndexName, err = reindexedName(sourceIndex)
 	}
 
@@ -153,8 +155,8 @@ func reindex(ctx context.Context, sourceIndex string, config *reindexConfig, wai
 			return nil, err
 		}
 
-		if destinationIndex == "" {
-			err = postReIndex(ctx, sourceIndex, newIndexName)
+		if !isClone {
+			err = postReIndex(ctx, sourceIndex, newIndexName, isClone)
 			if err != nil {
 				return nil, err
 			}
@@ -170,7 +172,7 @@ func reindex(ctx context.Context, sourceIndex string, config *reindexConfig, wai
 	}
 	taskID := response.TaskId
 
-	go asyncReIndex(taskID, sourceIndex, newIndexName)
+	go asyncReIndex(taskID, sourceIndex, newIndexName, isClone)
 
 	// Get the reindex task by ID
 	task, err := util.GetClient7().TasksGetTask().TaskId(taskID).Do(context.Background())
@@ -429,7 +431,7 @@ func isTaskCompleted(ctx context.Context, taskID string) (bool, error) {
 
 // go routine to track async re-indexing process for a given source and destination index.
 // it checks every 30s if task is completed or not.
-func asyncReIndex(taskID, source, destination string) {
+func asyncReIndex(taskID, source, destination string, isClone bool) {
 	SetCurrentProcess(taskID, source, destination)
 	isCompleted := make(chan bool, 1)
 	ticker := time.Tick(30 * time.Second)
@@ -447,7 +449,7 @@ func asyncReIndex(taskID, source, destination string) {
 			log.Println(logTag, taskID+" task completed successfully")
 			// remove process from current cache
 			RemoveCurrentProcess(taskID)
-			err := postReIndex(ctx, source, destination)
+			err := postReIndex(ctx, source, destination, isClone)
 			if err != nil {
 				log.Errorln(logTag, " post re-indexing error: ", err)
 			}


### PR DESCRIPTION
## What this PR does?
- when index is cloned i.e. `_reindex/{src}/{dest}` is called, then the original index shouldn't get deleted

## Test
https://www.loom.com/share/4a59666ddf4a4358931711a4951f0530

