### PR TITLE
feat(logs): add support to record response time for search requests 

### DIFF
--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -191,7 +191,6 @@ func (l *Logs) recordResponse(request *Request, w *httptest.ResponseRecorder, re
 		err := json.Unmarshal(responseBody, &resBody)
 		if err != nil {
 			log.Errorln(logTag, "error encountered while parsing the response: ", err)
-			return
 		}
 		// ignore error to record error logs
 		if err == nil {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR adds a feature to record the response time for search requests.
I tested it with `ES6` & `ES7` for `_search`, `_msearch` and `_reactivesearch` routes.

Note: `took` property doesn't work for `_msearch` requests for `ES6` so it'll not work for `_reactivesearch` too.

https://www.loom.com/share/752e861dd8ec4981a5f1679397e67e91

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
