### PR TITLE
fix: replicas and shards settings

### DIFF
--- a/plugins/auth/auth.go
+++ b/plugins/auth/auth.go
@@ -27,7 +27,7 @@ const (
 	defaultPublicKeyEsIndex   = ".publickey"
 	envJwtRsaPublicKeyLoc     = "JWT_RSA_PUBLIC_KEY_LOC"
 	envJwtRoleKey             = "JWT_ROLE_KEY"
-	settings                  = `{ "settings" : { "number_of_shards" : %d, "number_of_replicas" : %d } }`
+	settings                  = `{ "settings" : { "index.number_of_shards" : 1, "index.number_of_replicas" : %d } }`
 	publicKeyDocID            = "_public_key"
 )
 

--- a/plugins/auth/dao.go
+++ b/plugins/auth/dao.go
@@ -50,12 +50,11 @@ func (es *elasticsearch) createIndex(indexName, mapping string) (bool, error) {
 		return true, nil
 	}
 
-	// set the number_of_replicas to (nodes-1)
-	nodes, err := util.GetTotalNodes()
+	replicas := util.GetReplicas()
 	if err != nil {
 		return false, err
 	}
-	settings := fmt.Sprintf(mapping, nodes, nodes-1)
+	settings := fmt.Sprintf(mapping, replicas)
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(indexName).
 		Body(settings).

--- a/plugins/auth/dao.go
+++ b/plugins/auth/dao.go
@@ -51,9 +51,6 @@ func (es *elasticsearch) createIndex(indexName, mapping string) (bool, error) {
 	}
 
 	replicas := util.GetReplicas()
-	if err != nil {
-		return false, err
-	}
 	settings := fmt.Sprintf(mapping, replicas)
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(indexName).

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -42,9 +42,6 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	if err != nil {
-		return nil, err
-	}
 	settings := fmt.Sprintf(config, alias, replicas)
 	// Meta index doesn't exist, create one
 	indexName := alias + `-000001`

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -41,12 +41,11 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 		return es, nil
 	}
 
-	// set number_of_replicas to (nodes-1)
-	nodes, err := util.GetTotalNodes()
+	replicas := util.GetReplicas()
 	if err != nil {
 		return nil, err
 	}
-	settings := fmt.Sprintf(config, alias, nodes, nodes-1)
+	settings := fmt.Sprintf(config, alias, replicas)
 	// Meta index doesn't exist, create one
 	indexName := alias + `-000001`
 	// this works for ES6 client as well

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -22,8 +22,8 @@ const (
 	    }
 	  },
 	  "settings": {
-	    "number_of_shards": %d,
-	    "number_of_replicas": %d
+	    "index.number_of_shards": 1,
+	    "index.number_of_replicas": %d
 	  }
 	}`
 	rolloverConfig = `{

--- a/plugins/permissions/dao.go
+++ b/plugins/permissions/dao.go
@@ -32,12 +32,11 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 		return es, nil
 	}
 
-	// set number_of_replicas to (nodes-1)
-	nodes, err := util.GetTotalNodes()
+	replicas := util.GetReplicas()
 	if err != nil {
 		return nil, err
 	}
-	settings := fmt.Sprintf(mapping, nodes, nodes-1)
+	settings := fmt.Sprintf(mapping, replicas)
 
 	// Create a new meta index
 	_, err = util.GetClient7().CreateIndex(indexName).

--- a/plugins/permissions/dao.go
+++ b/plugins/permissions/dao.go
@@ -33,9 +33,6 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	if err != nil {
-		return nil, err
-	}
 	settings := fmt.Sprintf(mapping, replicas)
 
 	// Create a new meta index

--- a/plugins/permissions/permissions.go
+++ b/plugins/permissions/permissions.go
@@ -16,7 +16,7 @@ const (
 	typeName                  = "_doc"
 	envEsURL                  = "ES_CLUSTER_URL"
 	envPermissionEsIndex      = "PERMISSIONS_ES_INDEX"
-	settings                  = `{ "settings" : { "number_of_shards" : %d, "number_of_replicas" : %d } }`
+	settings                  = `{ "settings" : { "index.number_of_shards" : 1, "index.number_of_replicas" : %d } }`
 )
 
 var (

--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -235,8 +235,8 @@ func settingsOf(ctx context.Context, indexName string) (map[string]interface{}, 
 	settings := make(map[string]interface{})
 
 	settings["index"] = make(map[string]interface{})
-	settings["number_of_shards"] = indexSettings["number_of_shards"]
-	settings["number_of_replicas"] = indexSettings["number_of_replicas"]
+	settings["index.number_of_shards"] = 1
+	settings["index.number_of_replicas"] = util.GetReplicas()
 	analysis, found := indexSettings["analysis"]
 	if found {
 		settings["analysis"] = analysis

--- a/plugins/reindexer/mocks.go
+++ b/plugins/reindexer/mocks.go
@@ -29,7 +29,7 @@ func (m *mockES) mappingsOf(ctx context.Context, indexName string) (map[string]i
 }
 
 func (m *mockES) settingsOf(ctx context.Context, indexName string) (map[string]interface{}, error) {
-	data := []byte(`{"test":{"settings":{"index":{"creation_date":"1552665579942","number_of_shards":"5","number_of_replicas":"1","uuid":"hqhO4oiCReawwtOqFHaVLA","version":{"created":"6020499"},"provided_name":"test"}}}}`)
+	data := []byte(`{"test":{"settings":{"index":{"creation_date":"1552665579942","index.number_of_shards":"5","index.number_of_replicas":"1","uuid":"hqhO4oiCReawwtOqFHaVLA","version":{"created":"6020499"},"provided_name":"test"}}}}`)
 	var dec map[string]*elastic.IndicesGetSettingsResponse
 	_ = json.Unmarshal(data, &dec)
 
@@ -39,8 +39,8 @@ func (m *mockES) settingsOf(ctx context.Context, indexName string) (map[string]i
 	settings := make(map[string]interface{})
 
 	settings["index"] = make(map[string]interface{})
-	settings["number_of_shards"] = indexSettings["number_of_shards"]
-	settings["number_of_replicas"] = indexSettings["number_of_replicas"]
+	settings["index.number_of_shards"] = indexSettings["index.number_of_shards"]
+	settings["index.number_of_replicas"] = indexSettings["index.number_of_replicas"]
 	analysis, found := result.Settings["analysis"]
 	if found {
 		settings["analysis"] = analysis

--- a/plugins/users/dao.go
+++ b/plugins/users/dao.go
@@ -47,12 +47,11 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 		return es, nil
 	}
 
-	// set the number_of_replicas to (nodes-1)
-	nodes, err := util.GetTotalNodes()
+	replicas := util.GetReplicas()
 	if err != nil {
 		return nil, err
 	}
-	settings := fmt.Sprintf(mapping, nodes, nodes-1)
+	settings := fmt.Sprintf(mapping, replicas)
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(indexName).
 		Body(settings).

--- a/plugins/users/dao.go
+++ b/plugins/users/dao.go
@@ -48,9 +48,6 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	if err != nil {
-		return nil, err
-	}
 	settings := fmt.Sprintf(mapping, replicas)
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(indexName).

--- a/plugins/users/users.go
+++ b/plugins/users/users.go
@@ -14,7 +14,7 @@ const (
 	typeName            = "_doc"
 	envEsURL            = "ES_CLUSTER_URL"
 	defaultUsersEsIndex = ".users"
-	settings            = `{ "settings" : { "number_of_shards" : %d, "number_of_replicas" : %d } }`
+	settings            = `{ "settings" : { "index.number_of_shards" : 1, "index.number_of_replicas" : %d } }`
 )
 
 var (

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -9,11 +9,12 @@ import (
 
 // SetDefaultIndexTemplate to set default template for indexes
 func SetDefaultIndexTemplate() error {
-
-	settings := `{
-		"number_of_shards": 1,
+	replicas := GetReplicas()
+	settings := fmt.Sprintf(`{
+		"index.number_of_shards": 1,
 		"max_ngram_diff": 8,
 		"max_shingle_diff": 8,
+		"index.number_of_replicas": %d,
 		"analysis": {
 			"analyzer": {
 				"universal": {
@@ -81,7 +82,7 @@ func SetDefaultIndexTemplate() error {
 				}
 			}
 		} 
-	}`
+	}`, replicas)
 
 	mappings := `{
 		"dynamic_templates": [{

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -124,7 +124,7 @@ func SetDefaultIndexTemplate() error {
 	version := GetVersion()
 	if version == 7 {
 		defaultSetting := fmt.Sprintf(`{
-			"index_patterns": ["*"],
+			"index_patterns": ["-.*"],
 			"settings": %s,
 			"mappings": %s
 		}`, settings, mappings)
@@ -137,7 +137,7 @@ func SetDefaultIndexTemplate() error {
 
 	if version == 6 {
 		defaultSetting := fmt.Sprintf(`{
-			"index_patterns": ["*"],
+			"index_patterns": ["-.*"],
 			"settings": %s,
 			"mappings": {
 				"_doc": %s

--- a/util/shared.go
+++ b/util/shared.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"math"
 
 	es7 "github.com/olivere/elastic/v7"
 	es6 "gopkg.in/olivere/elastic.v6"
@@ -42,4 +43,15 @@ func GetTotalNodes() (int, error) {
 		return -1, err
 	}
 	return len(response.Nodes), nil
+}
+
+// GetReplicas calculates the number of replicas to set
+func GetReplicas() int {
+	nodes, err := GetTotalNodes()
+
+	if err != nil {
+		return int(0)
+	}
+
+	return int(math.Min(float64(1), float64(nodes-1)))
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
We were setting `shards` and `replicas` incorrectly for all the plugins and templates. Because of this cluster can use unnecessary space and can also go into red / yellow state while scaling.

Orginal settings `shards => number of nodes` & `replicas => number of nodes - 1`

New settings `shards => 1` & `replicas => min(1, number of nodes - 1)`

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?
https://www.loom.com/share/99fbc94976154825a23aafc7c9061686

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
