### PR TITLE
hotfix: use sniffing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/gobuffalo/packr v1.22.0
 	github.com/google/uuid v1.0.0
 	github.com/gorilla/mux v1.7.1
-	github.com/hashicorp/go-retryablehttp v0.6.3
 	github.com/olivere/elastic v6.2.21+incompatible
 	github.com/olivere/elastic/v7 v7.0.4
 	github.com/robfig/cron v1.1.0

--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 
@@ -46,20 +47,14 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 			Path:    r.URL.Path,
 			Body:    r.Body,
 			Headers: r.Header,
+			Params:  r.URL.Query(),
 		})
-		if err != nil {
-			log.Errorln(logTag, ": error while converting to retryable request for", r.URL.Path, err)
-			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
 
 		if err != nil {
 			log.Errorln(logTag, ": error fetching response for", r.URL.Path, err)
 			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		defer response.Body.Close()
 
 		// Copy the headers
 		for k, v := range response.Header {
@@ -73,6 +68,6 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		w.WriteHeader(response.StatusCode)
 
 		// Copy the body
-		io.Copy(w, response.Body)
+		io.Copy(w, bytes.NewReader(response.Body))
 	}
 }

--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -2,6 +2,7 @@ package elasticsearch
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -41,16 +42,23 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		log.Println(logTag, ": category=", *reqCategory, ", acl=", *reqACL, ", op=", *reqOp)
 		// Forward the request to elasticsearch
 		esClient := util.GetClient7()
-
-		response, err := esClient.PerformRequest(ctx, es7.PerformRequestOptions{
+		fmt.Println("options => ", es7.PerformRequestOptions{
 			Method:  r.Method,
 			Path:    r.URL.Path,
 			Body:    r.Body,
 			Headers: r.Header,
 			Params:  r.URL.Query(),
 		})
+		response, err := esClient.PerformRequest(ctx, es7.PerformRequestOptions{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Params:  r.URL.Query(),
+			Body:    r.Body,
+			Headers: r.Header,
+		})
 
 		if err != nil {
+			fmt.Println("=>", string(response.Body))
 			log.Errorln(logTag, ": error fetching response for", r.URL.Path, err)
 			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -68,6 +76,7 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		w.WriteHeader(response.StatusCode)
 
 		// Copy the body
+		fmt.Println("res", string(response.Body))
 		io.Copy(w, bytes.NewReader(response.Body))
 	}
 }

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -76,7 +76,7 @@ func initClient6() {
 	client6, err = es6.NewClient(
 		es6.SetURL(getURL()),
 		es6.SetRetrier(NewRetrier()),
-		es6.SetSniff(false),
+		es6.SetSniff(true),
 		es6.SetHttpClient(HTTPClient()),
 		es6.SetErrorLog(wrappedLoggerError),
 		es6.SetInfoLog(wrappedLoggerDebug),
@@ -99,7 +99,7 @@ func initClient7() {
 	client7, err = es7.NewClient(
 		es7.SetURL(getURL()),
 		es7.SetRetrier(NewRetrier()),
-		es7.SetSniff(false),
+		es7.SetSniff(true),
 		es7.SetHttpClient(HTTPClient()),
 		es7.SetErrorLog(wrappedLoggerError),
 		es7.SetInfoLog(wrappedLoggerDebug),


### PR DESCRIPTION
#### What does this do / why do we need it?

* Uses Oliver's client to forward HTTP request. This will help us use `setSniff` feature of Oliver's client which will help in forwarding requests over multiple nodes.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

https://www.loom.com/share/be4ce3f920654e4e99b6fe86a8e280f4

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
