### PR TITLE
fix: reindexing settings config

### DIFF
--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -235,8 +235,8 @@ func settingsOf(ctx context.Context, indexName string) (map[string]interface{}, 
 	settings := make(map[string]interface{})
 
 	settings["index"] = make(map[string]interface{})
-	settings["index.number_of_shards"] = 1
-	settings["index.number_of_replicas"] = util.GetReplicas()
+	settings["number_of_shards"] = 1
+	settings["number_of_replicas"] = util.GetReplicas()
 	analysis, found := indexSettings["analysis"]
 	if found {
 		settings["analysis"] = analysis


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

settings were not getting applied correctly while reindexing docs, because while fixing replicas and shards settings for all the plugins in v7.26.1, we accidentally add `index.` prefix to reindexing settings as well. Though it was already part of `settings["index"] map[string]interface{}` 

#### What should your reviewer look out for in this PR?

For reference check the line present before this changes.

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
