### PR TITLE
feat: add set sniffing env variable

### DIFF
--- a/config/manual.env
+++ b/config/manual.env
@@ -7,3 +7,4 @@ JWT_RSA_PUBLIC_KEY_LOC=sample/rsa-public
 HTTPS_CERT=sample/server.crt
 HTTPS_KEY=sample/server.key
 JWT_ROLE_KEY=role
+SET_SNIFFING=false

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -129,7 +129,7 @@ func initClient7() {
 	loggerT := log.New()
 	wrappedLoggerDebug := &WrapKitLoggerDebug{*loggerT}
 	wrappedLoggerError := &WrapKitLoggerError{*loggerT}
-	fmt.Println("=> isSniffing enabled", isSniffingEnabled())
+
 	client7, err = es7.NewClient(
 		es7.SetURL(getURL()),
 		es7.SetRetrier(NewRetrier()),

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -90,6 +90,15 @@ func getURL() string {
 	return url
 }
 
+func isSniffingEnabled() bool {
+	setSniffing := os.Getenv("SET_SNIFFING")
+	sniffing := true
+	if setSniffing == "false" {
+		sniffing = false
+	}
+	return sniffing
+}
+
 func initClient6() {
 	var err error
 
@@ -101,7 +110,7 @@ func initClient6() {
 	client6, err = es6.NewClient(
 		es6.SetURL(getURL()),
 		es6.SetRetrier(NewRetrier()),
-		es6.SetSniff(true),
+		es6.SetSniff(isSniffingEnabled()),
 		es6.SetHttpClient(HTTPClient()),
 		es6.SetErrorLog(wrappedLoggerError),
 		es6.SetInfoLog(wrappedLoggerDebug),
@@ -120,11 +129,11 @@ func initClient7() {
 	loggerT := log.New()
 	wrappedLoggerDebug := &WrapKitLoggerDebug{*loggerT}
 	wrappedLoggerError := &WrapKitLoggerError{*loggerT}
-
+	fmt.Println("=> isSniffing enabled", isSniffingEnabled())
 	client7, err = es7.NewClient(
 		es7.SetURL(getURL()),
 		es7.SetRetrier(NewRetrier()),
-		es7.SetSniff(true),
+		es7.SetSniff(isSniffingEnabled()),
 		es7.SetHttpClient(HTTPClient()),
 		es7.SetErrorLog(wrappedLoggerError),
 		es7.SetInfoLog(wrappedLoggerDebug),

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -92,9 +92,9 @@ func getURL() string {
 
 func isSniffingEnabled() bool {
 	setSniffing := os.Getenv("SET_SNIFFING")
-	sniffing := true
-	if setSniffing == "false" {
-		sniffing = false
+	sniffing := false
+	if setSniffing == "true" {
+		sniffing = true
 	}
 	return sniffing
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

* Adds support for `SET_SNIFFING` env variable.

This env is required because sniffing might not be enabled on the ElasticSearch cluster especially with `byoc` and `self hosted` arc.

#### What should your reviewer look out for in this PR?

https://www.loom.com/share/a7e4dca67a5f4b3286c109c9ff0157b8

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
