### PR TITLE
fix: hidden index util to compare es version other than 7.7.X

### DIFF
--- a/util/esclient.go
+++ b/util/esclient.go
@@ -75,7 +75,9 @@ func GetSemanticVersion() string {
 // HiddenIndexSettings to set plugin indices as hidden index
 func HiddenIndexSettings() string {
 	esVersion := GetSemanticVersion()
-	if strings.Contains(esVersion, "7.7") {
+	// Golang allows using comparision operators with strings
+	// test: https://play.golang.org/p/2F36GFe3L0A
+	if esVersion >= "7.7.0" {
 		return `"index.hidden": true,`
 	}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

* Fixes hidden index util to compare es version other than `7.7.x`

#### What should your reviewer look out for in this PR?

* Tested local arc build using ES v6.8.0, v7.7.1
* Ref test playground: https://play.golang.org/p/2F36GFe3L0A

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
