### PR TITLE
fix: set default format of cat apis to text

### DIFF
--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -52,10 +53,18 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 			}
 		}
 
+		params := r.URL.Query()
+		formatParam := params.Get("format")
+		// need to add check for `strings.Contains(r.URL.Path, "_cat")` because
+		// ACL for root route `/` is also `Cat`.
+		if *reqACL == acl.Cat && strings.Contains(r.URL.Path, "_cat") && formatParam == "" {
+			params.Add("format", "text")
+		}
+
 		requestOptions := es7.PerformRequestOptions{
 			Method:  r.Method,
 			Path:    r.URL.Path,
-			Params:  r.URL.Query(),
+			Params:  params,
 			Headers: headers,
 		}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

* Fixes default format `_cat` API response. Now default format is `text`

#### What should your reviewer look out for in this PR?

https://www.loom.com/share/26cbda78bb1b4ab5aa01476b7d00c33b

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
