### PR TITLE
fix: source filtering if request body is empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,16 @@
 module github.com/appbaseio/arc
 
 require (
-	github.com/apache/thrift v0.12.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gobuffalo/envy v1.6.15 // indirect
 	github.com/gobuffalo/packr v1.22.0
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/google/uuid v1.0.0
 	github.com/gorilla/mux v1.7.1
-	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/natefinch/lumberjack v2.0.1-0.20190411184413-94d9e492cc53+incompatible
 	github.com/olivere/elastic v6.2.21+incompatible
 	github.com/olivere/elastic/v7 v7.0.17
-	github.com/openzipkin/zipkin-go v0.1.6 // indirect
 	github.com/pkg/profile v1.5.0
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/robfig/cron v1.1.0
 	github.com/rogpeppe/go-internal v1.2.2 // indirect
 	github.com/rs/cors v1.6.0

--- a/plugins/elasticsearch/middleware.go
+++ b/plugins/elasticsearch/middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -194,7 +195,7 @@ func intercept(h http.HandlerFunc) http.HandlerFunc {
 					} else {
 						reqBody := make(map[string]interface{})
 						err := json.NewDecoder(req.Body).Decode(&reqBody)
-						if err != nil {
+						if err != nil && err != io.EOF {
 							log.Errorln(logTag, ":", err)
 							util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
 							return


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR fixes an existing bug with source filtering where search doesn't work if permission has `includeFields` and `excludeFields` defined and request body is empty.

https://www.loom.com/share/b55952e2b4dc47a5b84dc98b1296d4ba
#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
