### PR TITLE
fix: support os env PORT for heroku

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,8 +71,16 @@ func init() {
 	flag.StringVar(&envFile, "env", ".env", "Path to file with environment variables to load in KEY=VALUE format")
 	flag.StringVar(&logMode, "log", "", "Define to change the default log mode(error), other options are: debug(most verbose) and info")
 	flag.BoolVar(&listPlugins, "plugins", false, "List currently registered plugins")
-	flag.StringVar(&address, "addr", "", "Address to serve on")
-	flag.IntVar(&port, "port", 8000, "Port number")
+	flag.StringVar(&address, "addr", "0.0.0.0", "Address to serve on")
+	// env port for deployments like heroku where port is dynamically assigned
+	envPort := os.Getenv("PORT")
+	defaultPort := 8000
+	if envPort != "" {
+		portValue, _ := strconv.Atoi(envPort)
+		defaultPort = portValue
+	}
+	fmt.Println("=> port used", defaultPort)
+	flag.IntVar(&port, "port", defaultPort, "Port number")
 	flag.StringVar(&pluginDir, "pluginDir", "build/plugins", "Directory containing the compiled plugins")
 	flag.BoolVar(&https, "https", false, "Starts a https server instead of a http server if true")
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

* Uses os env PORT variable by default if available else uses default port
* Default address is set to "0.0.0.0"

#### What should your reviewer look out for in this PR?

* Tested and verified here https://github.com/appbaseio/appbaseio-heroku with beta release

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
