### PR TITLE
fix: remove search latency filter from logs for _logs endpoint

### DIFF
--- a/plugins/logs/dao_es6.go
+++ b/plugins/logs/dao_es6.go
@@ -36,15 +36,17 @@ func (es *elasticsearch) getRawLogsES6(ctx context.Context, logsFilter logsFilte
 	// apply index filtering logic
 	util.GetIndexFilterQueryEs6(query, logsFilter.Filter)
 
-	latencyRangeQuery := es6.NewRangeQuery("response.took")
-	if logsFilter.StartLatency != nil {
-		latencyRangeQuery.Gte(*logsFilter.StartLatency)
+	// only apply latency filter when start or end range is available
+	if logsFilter.StartLatency != nil || logsFilter.EndLatency != nil {
+		latencyRangeQuery := es6.NewRangeQuery("response.took")
+		if logsFilter.StartLatency != nil {
+			latencyRangeQuery.Gte(*logsFilter.StartLatency)
+		}
+		if logsFilter.EndLatency != nil {
+			latencyRangeQuery.Lte(*logsFilter.EndLatency)
+		}
+		query.Filter(latencyRangeQuery)
 	}
-	if logsFilter.EndLatency != nil {
-		latencyRangeQuery.Lte(*logsFilter.EndLatency)
-	}
-
-	query.Filter(latencyRangeQuery)
 
 	searchQuery := util.GetClient6().Search(es.indexName).
 		Query(query).


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR fixes a bug with request logs that have been introduced with the latency filtering changes (`_logs/search` endpoint). If latency range was not defined then it was filtering the logs with some `null` range and that was causing the issue.
Video with audio https://www.loom.com/share/d9c2f13d91594b4fbf612a96a94af7ee
https://www.loom.com/share/d6b2921e97bd4f048b76681cf6219696

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
