### PR TITLE
fix: wait for 72h instead of 24h before throwing payment req error

### DIFF
--- a/util/billing.go
+++ b/util/billing.go
@@ -45,7 +45,7 @@ func SetTimeValidity(time int64) {
 }
 
 // maxErrorTime before showing errors if invalid trial / plan in hours
-var maxErrorTime int64 = 24 // in hrs
+var maxErrorTime int64 = 72 // in hrs
 
 // NodeCount is the current node count, defaults to 1
 var NodeCount = 1

--- a/util/billing_test.go
+++ b/util/billing_test.go
@@ -52,15 +52,15 @@ func TestBilling(t *testing.T) {
 			SetTimeValidity(int64(timeValidityMock))
 			So(true, ShouldEqual, validateTimeValidity())
 		})
-		Convey("Validate TimeValidity: Negative value greater than 24 hours", func() {
+		Convey("Validate TimeValidity: Negative value greater than 72 hours", func() {
 			// Set TimeValidity to a positive value
-			var timeValidityMock = -(3600*24 + 10)
+			var timeValidityMock = -(3600*72 + 10)
 			SetTimeValidity(int64(timeValidityMock))
 			So(false, ShouldEqual, validateTimeValidity())
 		})
-		Convey("Validate TimeValidity: Negative value less than 24 hours", func() {
+		Convey("Validate TimeValidity: Negative value less than 72 hours", func() {
 			// Set TimeValidity to a positive value
-			var timeValidityMock = -(3600*24 - 10)
+			var timeValidityMock = -(3600*72 - 10)
 			SetTimeValidity(int64(timeValidityMock))
 			So(true, ShouldEqual, validateTimeValidity())
 		})


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
Updates the billing invalidity timeframe to 72h instead of 24h.

#### What should your reviewer look out for in this PR?
I have a question here: Would this change create any side effect with the reporting for the next billing interval? This is handled via Accounts API and not part of Arc.

#### Which issue(s) does this PR fix?
This PR adds a buffer of 72h (i.e. 3 days) when a payment has failed.

#### If this PR affects any API reference documentation, please share the updated endpoint references
No.

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
