### PR TITLE
fix: handle suggestions alias

### DIFF
--- a/plugins/reindexer/dao.go
+++ b/plugins/reindexer/dao.go
@@ -439,9 +439,12 @@ func getAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 		indicesList[i].DocsDeleted, _ = strconv.Atoi(fmt.Sprintf("%v", index.DocsDeleted))
 		var alias string
 		regex := ".*reindexed_[0-9]+"
-		rolloverPatter := ".*-[0-9]+"
-		rolloverRegex, _ := regexp.Compile(rolloverPatter)
+		rolloverPattern := ".*-[0-9]+"
+		suggestionsPattern := ".suggestions_*"
+
 		indexRegex, _ := regexp.Compile(regex)
+		rolloverRegex, _ := regexp.Compile(rolloverPattern)
+		suggestionsRegex, _ := regexp.Compile(suggestionsPattern)
 
 		for _, row := range aliases {
 			// match the alias for rollover index
@@ -449,6 +452,9 @@ func getAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 				alias = row.Alias
 				break
 			} else if row.Index == index.Index && indexRegex.MatchString(index.Index) {
+				alias = row.Alias
+				break
+			} else if row.Index == index.Index && suggestionsRegex.MatchString(index.Index) {
 				alias = row.Alias
 				break
 			}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR addresses the .suggestions alias not being returned via the `/_aliasedindices` endpoint. We only wish to return aliases for indexes which are renamed by appbase.io in this endpoint. The above PR respects that and adds a whitelist pattern for detecting .suggestions alias.

#### What should your reviewer look out for in this PR?

Have tested with frontend: https://www.loom.com/share/a45274045c0344df8ec0a7510424d817

#### Which issue(s) does this PR fix?

Explained above.

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

N/A.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
