### PR TITLE
fix: add check before reading response code

### DIFF
--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -79,7 +79,11 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		log.Println(fmt.Sprintf("TIME TAKEN BY ES: %dms", time.Since(start).Milliseconds()))
 		if err != nil {
 			log.Errorln(logTag, ": error while sending request :", r.URL.Path, err)
-			util.WriteBackError(w, err.Error(), response.StatusCode)
+			if response != nil {
+				util.WriteBackError(w, err.Error(), response.StatusCode)
+				return
+			}
+			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		// Copy the headers


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR fixes an issue while reading the status code when ES fails. Sometimes response from the `olivere/elastic` client can be `nil` so it is better to add a check to avoid nil pointer issue.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
