### PR TITLE
fix: update default cache limit for admin users

### DIFF
--- a/model/permission/defaults.go
+++ b/model/permission/defaults.go
@@ -96,6 +96,6 @@ var (
 		EcommIntegrationLimit: 30,
 		LogsLimit:             30,
 		SynonymsLimit:         30,
-		CacheLimit:            10,
+		CacheLimit:            30,
 	}
 )


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
This PR fixes a bug where the default cache limit for admin users was 10. The default limit for admin users must be 30 (similar to other categories).

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
