### PR TITLE
fix: ignore index.history.uuid setting while re-indexing

### DIFF
--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -116,6 +116,7 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 	}
 	// delete auto-generated metadata as this can't be re-used
 	delete(originalSettings, "index.history")
+	delete(originalSettings, "index.history.uuid")
 	delete(originalSettings, "index.provided_name")
 	delete(originalSettings, "index.uuid")
 	delete(originalSettings, "index.version")


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

Ignores `index.history.uuid` setting path from being copied while re-indexing since it is system assigned.

#### What should your reviewer look out for in this PR?

Test with the fix: https://www.loom.com/share/2ee7607667794a49b377ed6a61af9eb8

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
