### PR TITLE
fix: self re-index

### DIFF
--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -125,13 +125,12 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 	}
 
 	// initialize the map with passed index settings with a fallback to using the source index settings
-	var indexSettingsAsMap map[string]interface{}
 	indexSettingsAsMap, ok := config.Settings["index"].(map[string]interface{})
 	if !ok {
 		indexSettingsAsMap = originalSettings["index"].(map[string]interface{})
 	}
 
-	// delete auto-generated metadata as this can't be re-used
+	// delete system-generated metadata as this can't be passed by client
 	delete(indexSettingsAsMap, "history")
 	delete(indexSettingsAsMap, "history.uuid")
 	delete(indexSettingsAsMap, "provided_name")

--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -126,10 +126,8 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 
 	// initialize the map with passed index settings with a fallback to using the source index settings
 	var indexSettingsAsMap map[string]interface{}
-	indexSettings, ok := config.Settings["index"].(map[string]interface{})
-	if ok {
-		indexSettingsAsMap = indexSettings
-	} else {
+	indexSettingsAsMap, ok := config.Settings["index"].(map[string]interface{})
+	if !ok {
 		indexSettingsAsMap = originalSettings["index"].(map[string]interface{})
 	}
 

--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -114,15 +114,8 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 	if err != nil {
 		return nil, fmt.Errorf(`error fetching settings of index "%s": %v`, sourceIndex, err)
 	}
-	// delete auto-generated metadata as this can't be re-used
-	delete(originalSettings, "index.history")
-	delete(originalSettings, "index.history.uuid")
-	delete(originalSettings, "index.provided_name")
-	delete(originalSettings, "index.uuid")
-	delete(originalSettings, "index.version")
 
 	replicas := originalSettings["index.number_of_replicas"]
-
 	// If settings are not passed, we use the settings of the original index
 	if config.Settings == nil {
 		found := util.IsExists(Settings.String(), config.Action)
@@ -131,17 +124,22 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 		}
 	}
 
-	indexSettingsAsMap := originalSettings
-
-	// initialize the map with source index settings
-	originalIndexSettings, ok := originalSettings["index"].(map[string]interface{})
+	// initialize the map with passed index settings with a fallback to using the source index settings
+	var indexSettingsAsMap map[string]interface{}
+	indexSettings, ok := config.Settings["index"].(map[string]interface{})
 	if ok {
-		indexSettingsAsMap = originalIndexSettings
+		indexSettingsAsMap = indexSettings
+	} else {
+		indexSettingsAsMap = originalSettings["index"].(map[string]interface{})
 	}
 
-	if config.Settings["index"] != nil {
-		indexSettingsAsMap = config.Settings["index"].(map[string]interface{})
-	}
+	// delete auto-generated metadata as this can't be re-used
+	delete(indexSettingsAsMap, "history")
+	delete(indexSettingsAsMap, "history.uuid")
+	delete(indexSettingsAsMap, "provided_name")
+	delete(indexSettingsAsMap, "uuid")
+	delete(indexSettingsAsMap, "version")
+
 	// update replicas if passed by frontend
 	if replicasVal, ok := indexSettingsAsMap["number_of_replicas"]; ok {
 		replicas = replicasVal
@@ -155,14 +153,6 @@ func Reindex(ctx context.Context, sourceIndex string, config *ReindexConfig, wai
 	// override replicas to 0 while re-indexing
 	indexSettingsAsMap["number_of_replicas"] = 0
 	indexSettingsAsMap["auto_expand_replicas"] = false
-
-	// delete the values `index.settings` that we set in settingsOf method for originalSettings var as we have already set them as part of config.Settings[index] map
-	if _, ok := config.Settings["index.number_of_replicas"]; ok {
-		delete(config.Settings, "index.number_of_replicas")
-	}
-	if _, ok := config.Settings["index.number_of_shards"]; ok {
-		delete(config.Settings, "index.number_of_shards")
-	}
 
 	if config.Settings == nil {
 		config.Settings = make(map[string]interface{})


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

This PR fixes an issue where system generated index settings were being passed as part of the re-index request. It affects all the dashboard re-indexing requests that are made when editing the schema.

This PR also simplifies the logic by removing redundant code.

#### What should your reviewer look out for in this PR?

This PR affects how settings key is passed in the `_reindex` endpoint, there are three scenarios to test:

1. A request format for reindex similar to the one that dashboard uses, includes settings but not settings.index,
2. A request format for reindex where the request body doesn't contain the settings object (to test fallback case),
3. A request format for reindex where the request body contains settings.index object.

https://www.loom.com/share/2b4f86ad160a42e792da2317e2720b04



#### If this PR affects any API reference documentation, please share the updated endpoint references

No.

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
