### PR TITLE
fix: prevent healthpoint from showing the ES/appbase.io versions

### DIFF
--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -3,7 +3,6 @@ package elasticsearch
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -116,28 +115,11 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 
 func (es *elasticsearch) healthCheck() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		result, code, err := util.GetClient7().Ping(util.GetESURL()).Do(context.Background())
+		_, code, err := util.GetClient7().Ping(util.GetESURL()).Do(context.Background())
 		if err != nil {
 			log.Errorln(logTag, ": error fetching cluster health", err)
 			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
 		}
-		responseInBytes, err := json.Marshal(result)
-		if err != nil {
-			log.Errorln(logTag, ": error while marshalling the ping result", err)
-			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
-		}
-		var response map[string]interface{}
-		err2 := json.Unmarshal(responseInBytes, &response)
-		if err2 != nil {
-			log.Errorln(logTag, ": error while un-marshalling the response", err2)
-			util.WriteBackError(w, err2.Error(), http.StatusInternalServerError)
-		}
-		response["appbase_version"] = util.Version
-		finalResponseInBytes, err := json.Marshal(response)
-		if err != nil {
-			log.Errorln(logTag, ": error while marshalling the response", err)
-			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
-		}
-		util.WriteBackRaw(w, finalResponseInBytes, code)
+		util.WriteBackRaw(w, []byte{}, code)
 	}
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

This prevents the health endpoint from returning any discernible information about ES and appbase.io versions running for the cluster. Since health endpoint is open, this prevents security attacks that rely on a specific version.

#### What should your reviewer look out for in this PR?

Test that `/arc/health` endpoint returns no request body.

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
