### PR TITLE
fix(main.go): add OCI runtime detection check

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 	isRunTimeDocker := false
 
 	// Summarizing how we're detecting a container runtime:
-	// For Docker runtime, we check for the presence of `lxc` or `docker` string in the output of /proc/1/cgroup, https://stackoverflow.com/a/23558932/1221677
+	// For Docker runtime, we check for the presence of `lxc` or `docker` or `kubepods` string in the output of /proc/1/cgroup, https://stackoverflow.com/a/23558932/1221677
 	// For Podman (OCI) runtime, we check for the presence of /run/.containerenv, http://docs.podman.io/en/latest/markdown/podman-run.1.html
 	cmdToDetectRunTime := exec.Command("/bin/sh", "-c", "if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || grep -Eq '(lxc|docker|kubepods)' /proc/1/cgroup; then echo True; else echo False; fi")
 	var output bytes.Buffer

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	// Summarizing how we're detecting a container runtime:
 	// For Docker runtime, we check for the presence of `lxc` or `docker` string in the output of /proc/1/cgroup, https://stackoverflow.com/a/23558932/1221677
 	// For Podman (OCI) runtime, we check for the presence of /run/.containerenv, http://docs.podman.io/en/latest/markdown/podman-run.1.html
-	cmdToDetectRunTime := exec.Command("/bin/sh", "-c", "if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || grep -Eq '(lxc|docker)' /proc/1/cgroup; then echo True; else echo False; fi")
+	cmdToDetectRunTime := exec.Command("/bin/sh", "-c", "if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || grep -Eq '(lxc|docker|kubepods)' /proc/1/cgroup; then echo True; else echo False; fi")
 	var output bytes.Buffer
 	cmdToDetectRunTime.Stdout = &output
 	runtimeDetectErr := cmdToDetectRunTime.Run()

--- a/main.go
+++ b/main.go
@@ -103,7 +103,10 @@ func init() {
 func main() {
 	isRunTimeDocker := false
 
-	cmdToDetectRunTime := exec.Command("/bin/sh", "-c", "if [[ -f /.dockerenv ]] || grep -Eq '(lxc|docker)' /proc/1/cgroup; then echo True; else echo False; fi")
+	// Summarizing how we're detecting a container runtime:
+	// For Docker runtime, we check for the presence of `lxc` or `docker` string in the output of /proc/1/cgroup, https://stackoverflow.com/a/23558932/1221677
+	// For Podman (OCI) runtime, we check for the presence of /run/.containerenv, http://docs.podman.io/en/latest/markdown/podman-run.1.html
+	cmdToDetectRunTime := exec.Command("/bin/sh", "-c", "if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || grep -Eq '(lxc|docker)' /proc/1/cgroup; then echo True; else echo False; fi")
 	var output bytes.Buffer
 	cmdToDetectRunTime.Stdout = &output
 	runtimeDetectErr := cmdToDetectRunTime.Run()
@@ -117,17 +120,17 @@ func main() {
 	}
 
 	if isRunTimeDocker {
-		log.Println(logTag, "Runtime detected as docker container ...")
+		log.Println(logTag, "Runtime detected as docker or OCI container ...")
 		cmd := exec.Command("/bin/sh", "-c", "head -1 /proc/self/cgroup|cut -d/ -f3")
 		var out bytes.Buffer
 		cmd.Stdout = &out
 		err := cmd.Run()
 		id := out.String()
 		if err != nil {
-			log.Fatal(logTag, ": runtime detected as docker container: ", err)
+			log.Fatal(logTag, ": runtime detected as docker or OCI container: ", err)
 		}
 		if id == "" {
-			log.Fatal(logTag, ": runtime detected as docker container: machineid can not be empty")
+			log.Fatal(logTag, ": runtime detected as docker or OCI container: machineid can not be empty")
 		}
 		util.MachineID = strings.TrimSuffix(id, "\n")
 		util.RunTime = "Docker"


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
OCI runtime can't be detected via `/proc/1/cgroup` output. This PR adds an OCI runtime check based on the presence of `/run/.containerenv`, as officially recommended by the Podman docs [1].

> Additionally, a container environment file is created in each container to indicate to programs they are running in a container. This file is located at /run/.containerenv.

[1] http://docs.podman.io/en/latest/markdown/podman-run.1.html
