### PR TITLE
fix: return correct ES error code instead of 200 OK

### DIFF
--- a/plugins/elasticsearch/middleware.go
+++ b/plugins/elasticsearch/middleware.go
@@ -352,6 +352,6 @@ func intercept(h http.HandlerFunc) http.HandlerFunc {
 				body = bytes.Replace(body, []byte(`"`+indexName+`"`), []byte(`"`+index+`"`), -1)
 			}
 		}
-		util.WriteBackRaw(w, body, http.StatusOK)
+		util.WriteBackRaw(w, body, result.StatusCode)
 	}
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
Fixes the Elasticsearch error code instead of always returning 200 OK.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
