### PR TITLE
fix: always set hidden index to true for appbase.io indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.1
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/kljensen/snowball v0.6.0 // indirect
 	github.com/lithammer/fuzzysearch v1.1.3 // indirect
 	github.com/mackerelio/go-osstat v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/hashicorp/go-hclog v0.10.0 h1:b86HUuA126IcSHyC55WjPo7KtCOVeTCKIjr+3lB
 github.com/hashicorp/go-hclog v0.10.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-retryablehttp v0.6.3 h1:tuulM+WnToeqa05z83YLmKabZxrySOmJAd4mJ+s2Nfg=
 github.com/hashicorp/go-retryablehttp v0.6.3/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/appbaseio/reactivesearch-api/middleware/classify"
 	"github.com/appbaseio/reactivesearch-api/util"
+	"github.com/hashicorp/go-version"
 	es7 "github.com/olivere/elastic/v7"
 )
 
@@ -426,7 +427,12 @@ func GetAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 	var indicesList []AliasedIndices
 	v := url.Values{}
 	v.Set("format", "json")
-	v.Add("expand_wildcards", "all")
+
+	esVersion, _ := version.NewVersion(util.GetSemanticVersion())
+	hiddenIndexVersion, _ := version.NewVersion("7.7.0")
+	if esVersion.GreaterThanOrEqual(hiddenIndexVersion) {
+		v.Add("expand_wildcards", "all")
+	}
 
 	requestOptions := es7.PerformRequestOptions{
 		Method: "GET",

--- a/model/reindex/dao.go
+++ b/model/reindex/dao.go
@@ -426,10 +426,7 @@ func GetAliasedIndices(ctx context.Context) ([]AliasedIndices, error) {
 	var indicesList []AliasedIndices
 	v := url.Values{}
 	v.Set("format", "json")
-
-	if util.GetSemanticVersion() >= "7.7.0" {
-		v.Add("expand_wildcards", "all")
-	}
+	v.Add("expand_wildcards", "all")
 
 	requestOptions := es7.PerformRequestOptions{
 		Method: "GET",

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -98,14 +98,7 @@ func GetSemanticVersion() string {
 
 // HiddenIndexSettings to set plugin indices as hidden index
 func HiddenIndexSettings() string {
-	esVersion := GetSemanticVersion()
-	// Golang allows using comparision operators with strings
-	// test: https://play.golang.org/p/2F36GFe3L0A
-	if esVersion >= "7.7.0" {
-		return `"index.hidden": true,`
-	}
-
-	return ""
+	return `"index.hidden": true,`
 }
 
 func isSniffingEnabled() bool {

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -101,8 +101,6 @@ func GetSemanticVersion() string {
 func HiddenIndexSettings() string {
 	esVersion, _ := v.NewVersion(GetSemanticVersion())
 	hiddenIndexVersion, _ := v.NewVersion("7.7.0")
-	// Golang allows using comparision operators with strings
-	// test: https://play.golang.org/p/2F36GFe3L0A
 	if esVersion.GreaterThanOrEqual(hiddenIndexVersion) {
 		return `"index.hidden": true,`
 	}

--- a/util/esclient.go
+++ b/util/esclient.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	v "github.com/hashicorp/go-version"
 	es7 "github.com/olivere/elastic/v7"
 	log "github.com/sirupsen/logrus"
 	es6 "gopkg.in/olivere/elastic.v6"
@@ -98,7 +99,15 @@ func GetSemanticVersion() string {
 
 // HiddenIndexSettings to set plugin indices as hidden index
 func HiddenIndexSettings() string {
-	return `"index.hidden": true,`
+	esVersion, _ := v.NewVersion(GetSemanticVersion())
+	hiddenIndexVersion, _ := v.NewVersion("7.7.0")
+	// Golang allows using comparision operators with strings
+	// test: https://play.golang.org/p/2F36GFe3L0A
+	if esVersion.GreaterThanOrEqual(hiddenIndexVersion) {
+		return `"index.hidden": true,`
+	}
+
+	return ""
 }
 
 func isSniffingEnabled() bool {


### PR DESCRIPTION
#### What does this do / why do we need it?

Query hidden indices with aliased indices endpoint.

- String comparison logic doesn't work with strings. Example: comparison of "7.10.2" >= "7.7.0" returns false. We are now using the package https://github.com/hashicorp/go-version to do this.

#### What should your reviewer look out for in this PR?

- This has been tested with ES 7.10.2.
