### PR TITLE
Fixes for adding support for ElasticSearch v8

### DIFF
--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -54,9 +54,12 @@ func (es *elasticsearch) handler() http.HandlerFunc {
 		// Forward the request to elasticsearch
 		// remove content-type header from r.Headers as that is internally managed my oliver
 		// and can give following error if passed `{"error":{"code":500,"message":"elastic: Error 400 (Bad Request): java.lang.IllegalArgumentException: only one Content-Type header should be provided [type=content_type_header_exception]","status":"Internal Server Error"}}`
+		//
+		// Skip adding the Accept header since it is passed by default as */* and Elastic doesn't like that and ends up throwing
+		// Invalid media-type value on header [Accept] [type=media_type_header_exception]
 		headers := http.Header{}
 		for k := range r.Header {
-			if k == "Content-Type" || k == "Authorization" {
+			if k == "Content-Type" || k == "Authorization" || k == "Accept" {
 				continue
 			}
 			headers.Set(k, r.Header.Get(k))

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -181,7 +181,7 @@ func SetDefaultIndexTemplate() error {
 	}`
 
 	version := GetVersion()
-	if version == 7 {
+	if version == 7 || version == 8 {
 		defaultSetting := fmt.Sprintf(`{
 			"index_patterns": ["*"],
 			"settings": %s,


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

As of the time of creating this PR, there is a new version of ElasticSearch (8.0.0 Beta1) available for download. This PR tries to add fixes for all the breaking things that might stop ElasticSearch 8 from working with ` reactivesearch`.

#### What should your reviewer look out for in this PR?

--

#### Which issue(s) does this PR fix?

- Fixes issue of index not being created from the Dashboard Tutorial page (and indicating the index name is not unique due to a 400 error).
- Fix issue of `_settings` not working due to invalid `max_ngram_diff` value. This is set by default value being set while init of the API.

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
