### PR TITLE
fix: issue with caching of request based rules

### DIFF
--- a/main.go
+++ b/main.go
@@ -333,7 +333,7 @@ func main() {
 	util.SetDefaultIndexTemplate()
 	util.SetSystemIndexTemplate()
 	// map of specific plugins
-	sequencedPlugins := []string{"analytics.so", "cache.so", "searchrelevancy.so", "rules.so", "functions.so", "suggestions.so", "storedquery.so", "analyticsrequest.so", "applycache.so"}
+	sequencedPlugins := []string{"analytics.so", "searchrelevancy.so", "rules.so", "cache.so", "suggestions.so", "storedquery.so", "analyticsrequest.so", "applycache.so"}
 	sequencedPluginsByPath := make(map[string]string)
 
 	var elasticSearchPath, reactiveSearchPath string

--- a/plugins/querytranslate/geo_query_test.go
+++ b/plugins/querytranslate/geo_query_test.go
@@ -27,7 +27,7 @@ func TestGeoDropdownWithValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceDropdown"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceDropdown_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"geo_distance":{"distance":"10mi","location":"51.5073509, -0.1277583"}},"size":100}
 `)
 	})
@@ -69,7 +69,7 @@ func TestGeoDistanceSliderWithValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceSlider"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceSlider_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"geo_distance":{"distance":"10mi","location":"51.5073509, -0.1277583"}},"size":100}
 `)
 	})
@@ -97,7 +97,7 @@ func TestGeoDistanceSliderWithNestedField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceSlider"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"GeoDistanceSlider_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"nested":{"path":"location.raw","query":{"geo_distance":{"distance":"10mi","location":"51.5073509, -0.1277583"}}}},"size":100}
 `)
 	})

--- a/plugins/querytranslate/range_query_test.go
+++ b/plugins/querytranslate/range_query_test.go
@@ -31,7 +31,7 @@ func TestMultiRangeWithValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"boost":1,"minimum_should_match":1,"should":[{"range":{"average_rating":{"boost":2,"gte":0,"lte":3}}},{"range":{"average_rating":{"boost":2,"gte":3,"lte":4}}}]}},"size":3}
 `)
 	})
@@ -58,7 +58,7 @@ func TestRangeSliderWithValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"range":{"ratings_count":{"boost":2,"gte":3000,"lte":50000}}},"size":3}
 `)
 	})
@@ -86,7 +86,7 @@ func TestRangeSliderWithNullValues(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"should":[{"range":{"ratings_count":{"boost":2,"gte":3000,"lte":50000}}},{"bool":{"must_not":{"exists":{"field":"ratings_count"}}}}]}},"size":3}
 `)
 	})
@@ -114,7 +114,7 @@ func TestRangeSliderWithNestedField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"nested":{"path":"ratings_count.raw","query":{"range":{"ratings_count":{"boost":2,"gte":3000,"lte":50000}}}}},"size":3}
 `)
 	})
@@ -144,7 +144,7 @@ func TestRangeSliderWithHistogram(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"ratings_count.raw":{"aggs":{"ratings_count":{"histogram":{"field":"ratings_count","interval":470,"offset":3000}}},"nested":{"path":"ratings_count.raw"}}},"query":{"nested":{"path":"ratings_count.raw","query":{"range":{"ratings_count":{"boost":2,"gte":3000,"lte":50000}}}}},"size":3}
 `)
 	})
@@ -169,7 +169,7 @@ func TestDatePicker(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"DateSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"DateSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"range":{"date_from":{"gte":"20170510"}}},"size":40}
 `)
 	})
@@ -203,9 +203,9 @@ func TestDateRangePicker(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"DateSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"DateSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"range":{"date_from":{"gte":"20170515"}}},"size":40}
-{"preference":"DateSensor"}
+{"preference":"DateSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"range":{"date_to":{"lte":"20170518"}}},"size":40}
 `)
 	})

--- a/plugins/querytranslate/search_query_test.go
+++ b/plugins/querytranslate/search_query_test.go
@@ -17,7 +17,7 @@ func transformQuery(query map[string]interface{}) (string, error) {
 	if err2 != nil {
 		return "", err2
 	}
-	return translateQuery(body)
+	return translateQuery(body, "127.0.0.1")
 }
 
 func TestQueryWithValue(t *testing.T) {
@@ -36,7 +36,7 @@ func TestQueryWithValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -56,7 +56,7 @@ func TestBasicQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"match_all":{}}}
 `)
 	})
@@ -77,7 +77,7 @@ func TestWithMultipleDataFields(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
@@ -184,7 +184,7 @@ func TestWithFieldWeights(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
@@ -214,7 +214,7 @@ func TestWithFieldWeightsNewFromat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
@@ -237,7 +237,7 @@ func TestQueryFormat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -260,7 +260,7 @@ func TestSearchOperators(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"simple_query_string":{"default_operator":"or","fields":["original_title"],"query":"^harry"}},"size":20}
 `)
 	})
@@ -283,7 +283,7 @@ func TestQueryWithFuzziness(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":2,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -306,7 +306,7 @@ func TestQueryWithIncludeFields(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["original_title.raw"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -329,7 +329,7 @@ func TestQueryWithExcludeFields(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":["original_title.raw"],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harry Potter Collection (Harry Potter, #1-6)","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -352,7 +352,7 @@ func TestQueryFrom(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"from":40,"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"Harvesting the Heart","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -375,7 +375,7 @@ func TestQueryHighlight(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -399,7 +399,7 @@ func TestQueryHighlightField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"],"require_field_match":false},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
@@ -422,7 +422,7 @@ func TestQueryNestedField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"nested":{"path":"original_title.raw","query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}},"size":20}
 `)
 	})
@@ -445,7 +445,7 @@ func TestQueryWithAggregationField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"CarSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"CarSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"aggs":{"brand.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword"}}}]}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"cross_fields"}},{"multi_match":{"fields":["brand"],"fuzziness":0,"operator":"or","query":"bmw","type":"best_fields"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -468,7 +468,7 @@ func TestQueryWithCategoryField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -492,7 +492,7 @@ func TestQueryWithCategories(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"term":{"authors.raw":"J.K. Rowling"}}]}},"size":10}
 `)
 	})
@@ -516,7 +516,7 @@ func TestQueryWithCategoryAndAggregationField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_title.keyword":{"aggs":{"original_title.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"original_title.keyword":{"terms":{"field":"original_title.keyword"}}}]}},"title.keyword":{"terms":{"field":"title.keyword"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"ha","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"ha","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"ha","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"ha","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -541,7 +541,7 @@ func TestCategorySearchWithQueryFormat(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor"}
+		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
@@ -562,7 +562,7 @@ func TestBasicReactiveList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"match_all":{}},"size":3}
 `)
 	})
@@ -584,7 +584,7 @@ func TestBasicReactiveListWithSortAscending(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"match_all":{}},"size":3,"sort":[{"original_title.raw":{"order":"asc"}}]}
 `)
 	})
@@ -606,7 +606,7 @@ func TestBasicReactiveListWithSortDescending(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"match_all":{}},"size":3,"sort":[{"original_title.raw":{"order":"desc"}}]}
 `)
 	})
@@ -637,7 +637,7 @@ func TestReactiveAnd(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
@@ -668,7 +668,7 @@ func TestReactiveOr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
@@ -699,7 +699,7 @@ func TestReactiveNot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must_not":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
@@ -737,7 +737,7 @@ func TestReactiveWithArray(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"potter","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase_prefix"}}]}}]}}]}},"size":20}
 `)
 	})
@@ -765,7 +765,7 @@ func TestBasicReactiveListWithDefaultQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"terms":{"country":["India"]}},"size":3}
 `)
 	})
@@ -792,7 +792,7 @@ func TestBasicReactiveListWithDefaultQueryWithoutField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"terms":{"country":["India"]}},"size":3}
 `)
 	})
@@ -820,7 +820,7 @@ func TestBasicDataSearchWithDefaultQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"terms":{"country":["India"]}},"size":3,"sort":[{"original_title.raw":{"order":"desc"}}]}
 `)
 	})
@@ -858,7 +858,7 @@ func TestBasicDataSearchWithCustomQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"terms":{"country":["india"]}}}}]}},"size":10}
 `)
 	})
@@ -894,7 +894,7 @@ func TestBasicDataSearchWithCustomQueryWithoutField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult"}
+		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"terms":{"country":["india"]}}}}]}},"size":10}
 `)
 	})
@@ -943,7 +943,7 @@ func TestQueryWithReact(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		So(transformedQuery, ShouldResemble, `{"preference":"Results"}
+		So(transformedQuery, ShouldResemble, `{"preference":"Results_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"batman","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase_prefix"}}]}}]}},{"bool":{"minimum_should_match":1,"should":[{"bool":{"should":[{"terms":{"genres_new_data.keyword":["Romance"]}}]}}]}}]}},"size":5,"sort":[{"original_title.keyword":{"order":"asc"}}]}
 `)
 	})

--- a/plugins/querytranslate/term_query_test.go
+++ b/plugins/querytranslate/term_query_test.go
@@ -23,7 +23,7 @@ func TestMultiListWithDefaultValue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_series.raw":{"terms":{"field":"original_series.raw","order":{"_count":"desc"},"size":100}}},"query":{"match_all":{}},"size":100}
 `)
 	})
@@ -83,9 +83,9 @@ func TestMultiDropdownList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_series.raw":{"terms":{"field":"original_series.raw","order":{"_count":"desc"}}}},"query":{"match_all":{}},"size":0}
-{"preference":"SearchResult"}
+{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"bool":{"must":[{"term":{"original_series.raw":"In Death"}},{"term":{"original_series.raw":"Discworld"}}]}}}}]}},"size":10}
 `)
 	})
@@ -115,9 +115,9 @@ func TestMultiDataList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"group.group_topics.topic_name_raw.raw":{"terms":{"field":"group.group_topics.topic_name_raw.raw","order":{"_count":"desc"}}}},"query":{"match_all":{}},"size":0}
-{"preference":"SearchResult"}
+{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"bool":{"should":[{"terms":{"group.group_topics.topic_name_raw.raw":["Social","Adventure"]}}]}}]}}]}},"size":5}
 `)
 	})
@@ -147,9 +147,9 @@ func TestSingleDataList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"group.group_topics.topic_name_raw.raw":{"terms":{"field":"group.group_topics.topic_name_raw.raw","order":{"_count":"desc"}}}},"query":{"match_all":{}},"size":0}
-{"preference":"SearchResult"}
+{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"term":{"group.group_topics.topic_name_raw.raw":"Social"}}]}}]}},"size":5}
 `)
 	})
@@ -179,9 +179,9 @@ func TestToggle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"CitySensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"group.group_topics.topic_name_raw.raw":{"terms":{"field":"group.group_topics.topic_name_raw.raw","order":{"_count":"desc"}}}},"query":{"match_all":{}},"size":0}
-{"preference":"SearchResult"}
+{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"bool":{"should":[{"terms":{"group.group_topics.topic_name_raw.raw":["Social","Adventure"]}}]}}]}}]}},"size":5}
 `)
 	})
@@ -206,7 +206,7 @@ func TestMultiListWithMissingBucket(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_series.raw":{"terms":{"field":"original_series.raw","missing":"N/A","order":{"_count":"desc"},"size":100}}},"query":{"match_all":{}},"size":100}
 `)
 	})
@@ -232,7 +232,7 @@ func TestMultiListWithAfterKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"composite":{"after":{"brand.keyword":"Chevrolet"},"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword"}}}]}}},"query":{"match_all":{}},"size":10}
 `)
 	})
@@ -262,7 +262,7 @@ func TestMultiListWithDefaultQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"SearchResult"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_series.raw":{"terms":{"field":"original_series.raw","order":{"_count":"desc"},"size":100}}},"query":{"terms":{"country":["India"]}},"size":100}
 `)
 	})
@@ -301,7 +301,7 @@ func TestMultiListWithCustomQuery(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"SearchResult"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"term":{"city":"San Fransisco"}}}}]}},"size":100}
 `)
 	})
@@ -328,7 +328,7 @@ func TestMultiListWithSortDesc(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"composite":{"after":{"brand.keyword":"Maybach"},"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword","order":"desc"}}}]}}},"query":{"match_all":{}},"size":10}
 `)
 	})
@@ -355,7 +355,7 @@ func TestMultiListWithSortByCount(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
-		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor"}
+		convey.So(transformedQuery, convey.ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
 {"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"composite":{"after":{"brand.keyword":"Chevrolet"},"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword"}}}]}}},"query":{"match_all":{}},"size":10}
 `)
 	})

--- a/plugins/querytranslate/translate_test.go
+++ b/plugins/querytranslate/translate_test.go
@@ -18,7 +18,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldBeError)
 	})
 	Convey("with single dataField for geo", t, func() {
@@ -32,7 +32,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldBeNil)
 	})
 	Convey("with multiple dataFields for term", t, func() {
@@ -46,7 +46,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldBeError)
 	})
 	Convey("with single dataField for term", t, func() {
@@ -60,7 +60,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldBeNil)
 	})
 	Convey("with multiple dataFields for search", t, func() {
@@ -73,7 +73,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldBeNil)
 	})
 	Convey("without dataField", t, func() {
@@ -88,7 +88,7 @@ func TestTranslateQuery(t *testing.T) {
 				},
 			},
 		}
-		_, err := translateQuery(rsQuery)
+		_, err := translateQuery(rsQuery, "127.0.0.1")
 		So(err, ShouldNotBeNil)
 	})
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
- Fixes the issue where request based query rules or search relevance preferences based modifications wouldn't have been cached as `cache` plugin's middleware was loaded prior to the `rules` plugin.
  - It would cache the request prior to rule / search relevancy being applied
  - Post rule / search relevancy application, as the request would potentially look different, the cache would register a miss and a query to `Elasticsearch` would instead get fired.

- This PR also fixes a side effect of query translate plugin's tests breaking as a result of the change in how preference is set at request time.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
