### PR TITLE
Fix issue of failing index mapping get method on Elastic Search v8

### DIFF
--- a/util/migration.go
+++ b/util/migration.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/appbaseio/reactivesearch-api/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -55,7 +54,7 @@ type IndexMappingResponse map[string]interface{}
 // expected to be handled by the calling function.
 func GetIndexMapping(indexName string) (resp IndexMappingResponse, err error) {
 	// Keep a constant variable to store the URL
-	MappingBaseURL := util.GetESURL() + "/%s/_mapping"
+	MappingBaseURL := GetESURL() + "/%s/_mapping"
 
 	// Declare the mapping response variable
 	var data IndexMappingResponse

--- a/util/migration.go
+++ b/util/migration.go
@@ -1,5 +1,10 @@
 package util
 
+import (
+	"fmt"
+	"net/http"
+)
+
 type Error struct {
 	Message string
 	Err     error
@@ -26,4 +31,14 @@ func GetMigrationScripts() []Migration {
 // AddMigrationScript allows you to add a migration script
 func AddMigrationScript(migration Migration) {
 	migrationScripts = append(migrationScripts, migration)
+}
+
+// Fetch the index mapping manually using the following function
+// Make the request directly and return the response accordingly.
+func GetIndexMapping(indexName string) (resp *http.Response, err error) {
+	// Keep a constant variable to store the URL
+	MappingBaseURL := "/%s/_mapping"
+
+	response, err := http.Get(fmt.Sprintf(MappingBaseURL, indexName))
+	return response, err
 }

--- a/util/migration.go
+++ b/util/migration.go
@@ -1,8 +1,13 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+
+	"github.com/appbaseio/reactivesearch-api/util"
+	log "github.com/sirupsen/logrus"
 )
 
 type Error struct {
@@ -33,12 +38,44 @@ func AddMigrationScript(migration Migration) {
 	migrationScripts = append(migrationScripts, migration)
 }
 
+// Handle unstrctured JSON data from the mapping endpoint
+type IndexMappingResponse map[string]interface{}
+
 // Fetch the index mapping manually using the following function
 // Make the request directly and return the response accordingly.
-func GetIndexMapping(indexName string) (resp *http.Response, err error) {
+// We will extract the unstructured JSON data from the endpoint
+// and parse it to a map so that it can be directly used.
+//
+// On error, an empty data body will be returned along with the
+// error itself.
+//
+// Errors will be returned accordingly and verbosed if the error
+// occurs while extracting the JSON data. There will be no verbose
+// if the error occurs while hitting the endpoint. Those errors are
+// expected to be handled by the calling function.
+func GetIndexMapping(indexName string) (resp IndexMappingResponse, err error) {
 	// Keep a constant variable to store the URL
-	MappingBaseURL := "/%s/_mapping"
+	MappingBaseURL := util.GetESURL() + "/%s/_mapping"
+
+	// Declare the mapping response variable
+	var data IndexMappingResponse
 
 	response, err := http.Get(fmt.Sprintf(MappingBaseURL, indexName))
-	return response, err
+
+	if err != nil {
+		return data, err
+	}
+
+	defer response.Body.Close()
+
+	// Read the body into bytes and try to unmarshall
+	// into JSON data.
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Errorln("error while reading JSON data: ", err)
+		return data, err
+	}
+
+	json.Unmarshal(body, &data)
+	return data, err
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

We are currently using the Olivere/elastic client to make all the internal calls to Elastic. However, in certain places (migration related code), the client is being used to fetch the index mapping. This part is failing on ElasticSearch v8 because of the `_mapping/_all` endpoint being deprecated. As of now the `_mapping` endpoint is expected to be used.

#### What should your reviewer look out for in this PR?

I raised an issue with the Elastic client being used currently that can be found [here](https://github.com/olivere/elastic/issues/1555). However, the author said Elastic v8 is not supported yet. Thus this workaround attempts to fix that by adding a custom method to get the index details from Elastic.

#### Which issue(s) does this PR fix?

Adds support for ES v8

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
