### PR TITLE
feat(suggestions): improves precision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/appbaseio/reactivesearch-api
 
 require (
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/bbalet/stopwords v1.0.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/denisbrodbeck/machineid v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gertd/go-pluralize v0.1.7 // indirect
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/gobuffalo/envy v1.6.15 // indirect
 	github.com/gobuffalo/packr v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
@@ -410,8 +409,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
-github.com/microcosm-cc/bluemonday v1.0.15 h1:J4uN+qPng9rvkBZBoBb8YGR+ijuklIMpSOZZLjYpbeY=
-github.com/microcosm-cc/bluemonday v1.0.15/go.mod h1:ZLvAzeakRwrGnzQEvstVzVt3ZpqOF2+sdFr0Om+ce30=
 github.com/microcosm-cc/bluemonday v1.0.16 h1:kHmAq2t7WPWLjiGvzKa5o3HzSfahUKiOq7fAPUiMNIc=
 github.com/microcosm-cc/bluemonday v1.0.16/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
+github.com/gertd/go-pluralize v0.1.7 h1:RgvJTJ5W7olOoAks97BOwOlekBFsLEyh00W48Z6ZEZY=
+github.com/gertd/go-pluralize v0.1.7/go.mod h1:O4eNeeIf91MHh1GJ2I47DNtaesm66NYvjYgAahcqSDQ=
 github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/oTPg8=
 github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=

--- a/plugins/querytranslate/querytranslate.go
+++ b/plugins/querytranslate/querytranslate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/plugins"
+	pluralize "github.com/gertd/go-pluralize"
 )
 
 const (
@@ -13,8 +14,9 @@ const (
 )
 
 var (
-	singleton *QueryTranslate
-	once      sync.Once
+	rsPluralize *pluralize.Client
+	singleton   *QueryTranslate
+	once        sync.Once
 )
 
 // QueryTranslate plugin deals with managing query translation.
@@ -24,7 +26,10 @@ type QueryTranslate struct{}
 // should be the only way (both within or outside the package) to fetch
 // the instance of the plugin, in order to avoid stateless duplicates.
 func Instance() *QueryTranslate {
-	once.Do(func() { singleton = &QueryTranslate{} })
+	once.Do(func() {
+		singleton = &QueryTranslate{}
+		rsPluralize = pluralize.NewClient()
+	})
 	return singleton
 }
 

--- a/plugins/querytranslate/search.go
+++ b/plugins/querytranslate/search.go
@@ -143,7 +143,7 @@ func (query *Query) generateShouldQuery() (interface{}, error) {
 		var finalQuery = []map[string]interface{}{
 			{
 				"multi_match": map[string]interface{}{
-					"query":    query.Value,
+					"query":    getPlural(query.Value),
 					"fields":   fields,
 					"type":     "cross_fields",
 					"operator": And.String(),
@@ -215,7 +215,7 @@ func (query *Query) generateShouldQuery() (interface{}, error) {
 	var finalQuery = []map[string]interface{}{
 		{
 			"multi_match": map[string]interface{}{
-				"query":    query.Value,
+				"query":    getPlural(query.Value),
 				"fields":   fields,
 				"type":     "cross_fields",
 				"operator": Or.String(),

--- a/plugins/querytranslate/search_query_test.go
+++ b/plugins/querytranslate/search_query_test.go
@@ -37,7 +37,7 @@ func TestQueryWithValue(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -78,7 +78,7 @@ func TestWithMultipleDataFields(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title","original_title.raw"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
 }
@@ -185,7 +185,7 @@ func TestWithFieldWeights(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
 }
@@ -215,7 +215,7 @@ func TestWithFieldWeightsNewFromat(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title^1.00","original_title.raw^3.00"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title^1.0","original_title.raw^1.0"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}
 `)
 	})
 }
@@ -238,7 +238,7 @@ func TestQueryFormat(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"and","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -284,7 +284,7 @@ func TestQueryWithFuzziness(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":2,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":2,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -353,7 +353,7 @@ func TestQueryFrom(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"from":40,"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"Harvesting the Heart","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"from":40,"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Hearts","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"Harvesting the Heart","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"Harvesting the Heart","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -376,7 +376,7 @@ func TestQueryHighlight(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"]},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -400,7 +400,7 @@ func TestQueryHighlightField(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"],"require_field_match":false},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"highlight":{"fields":{"original_title":{}},"post_tags":["\u003c/mark\u003e"],"pre_tags":["\u003cmark\u003e"],"require_field_match":false},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":20}
 `)
 	})
 }
@@ -423,7 +423,7 @@ func TestQueryNestedField(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"nested":{"path":"original_title.raw","query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"nested":{"path":"original_title.raw","query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}},"size":20}
 `)
 	})
 }
@@ -446,7 +446,7 @@ func TestQueryWithAggregationField(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"CarSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"aggs":{"brand.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword"}}}]}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"cross_fields"}},{"multi_match":{"fields":["brand"],"fuzziness":0,"operator":"or","query":"bmw","type":"best_fields"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase_prefix"}}]}},"size":10}
+{"_source":{"excludes":[],"includes":["*"]},"aggs":{"brand.keyword":{"aggs":{"brand.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"brand.keyword":{"terms":{"field":"brand.keyword"}}}]}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["brand"],"operator":"or","query":"bmws","type":"cross_fields"}},{"multi_match":{"fields":["brand"],"fuzziness":0,"operator":"or","query":"bmw","type":"best_fields"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase"}},{"multi_match":{"fields":["brand"],"operator":"or","query":"bmw","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
 }
@@ -469,7 +469,7 @@ func TestQueryWithCategoryField(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":10}
+{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
 }
@@ -493,7 +493,7 @@ func TestQueryWithCategories(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"term":{"authors.raw":"J.K. Rowling"}}]}},"size":10}
+{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"term":{"authors.raw":"J.K. Rowling"}}]}},"size":10}
 `)
 	})
 }
@@ -517,7 +517,7 @@ func TestQueryWithCategoryAndAggregationField(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_title.keyword":{"aggs":{"original_title.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"original_title.keyword":{"terms":{"field":"original_title.keyword"}}}]}},"title.keyword":{"terms":{"field":"title.keyword"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"ha","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"ha","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"ha","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"ha","type":"phrase_prefix"}}]}},"size":10}
+{"_source":{"excludes":[],"includes":["*"]},"aggs":{"original_title.keyword":{"aggs":{"original_title.keyword":{"top_hits":{"size":1}}},"composite":{"size":10,"sources":[{"original_title.keyword":{"terms":{"field":"original_title.keyword"}}}]}},"title.keyword":{"terms":{"field":"title.keyword"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"has","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"fuzziness":0,"operator":"or","query":"ha","type":"best_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"or","query":"ha","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"ha","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
 }
@@ -542,7 +542,7 @@ func TestCategorySearchWithQueryFormat(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"BookSensor_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":10}
+{"_source":{"excludes":[],"includes":["*"]},"aggs":{"authors.raw":{"terms":{"field":"authors.raw"}}},"query":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title","original_title.search"],"operator":"and","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"and","query":"harry","type":"phrase_prefix"}}]}},"size":10}
 `)
 	})
 }
@@ -638,7 +638,7 @@ func TestReactiveAnd(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
 }
@@ -669,7 +669,7 @@ func TestReactiveOr(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
 }
@@ -700,7 +700,7 @@ func TestReactiveNot(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must_not":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must_not":{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}}}}]}},"size":20}
 `)
 	})
 }
@@ -738,7 +738,7 @@ func TestReactiveWithArray(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"SearchResult_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"potter","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase_prefix"}}]}}]}}]}},"size":20}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"harries","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"harry","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"harry","type":"phrase_prefix"}}]}},{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"potters","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"potter","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"potter","type":"phrase_prefix"}}]}}]}}]}},"size":20}
 `)
 	})
 }
@@ -944,7 +944,7 @@ func TestQueryWithReact(t *testing.T) {
 			t.Fatalf("Test Failed %v instead\n", err)
 		}
 		So(transformedQuery, ShouldResemble, `{"preference":"Results_127.0.0.1"}
-{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"batman","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase_prefix"}}]}}]}},{"bool":{"minimum_should_match":1,"should":[{"bool":{"should":[{"terms":{"genres_new_data.keyword":["Romance"]}}]}}]}}]}},"size":5,"sort":[{"original_title.keyword":{"order":"asc"}}]}
+{"_source":{"excludes":[],"includes":["*"]},"query":{"bool":{"must":[{"bool":{"must":[{"bool":{"minimum_should_match":1,"should":[{"multi_match":{"fields":["original_title"],"operator":"or","query":"batmen","type":"cross_fields"}},{"multi_match":{"fields":["original_title"],"fuzziness":0,"operator":"or","query":"batman","type":"best_fields"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase"}},{"multi_match":{"fields":["original_title"],"operator":"or","query":"batman","type":"phrase_prefix"}}]}}]}},{"bool":{"minimum_should_match":1,"should":[{"bool":{"should":[{"terms":{"genres_new_data.keyword":["Romance"]}}]}}]}}]}},"size":5,"sort":[{"original_title.keyword":{"order":"asc"}}]}
 `)
 	})
 }

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -446,7 +446,7 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 	if config.Value != "" {
 		tags := getPredictiveSuggestionsTags(config.HighlightConfig)
 		for _, suggestion := range *suggestions {
-			fieldValues := strings.Split(NormalizeValue(suggestion.Label), " ")
+			fieldValues := strings.Split(NormalizeValue(getTextFromHTML(suggestion.Label)), " ")
 			fvl := len(fieldValues)
 			queryValues := strings.Split(NormalizeValue(config.Value), " ")
 			suffixStarts := 0
@@ -489,7 +489,7 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 					} else {
 						matchQuery = config.Value
 					}
-					suggestionPhrase := matchQuery + " " + tags.PreTags + highlightPhrase + tags.PostTags
+					suggestionPhrase := fmt.Sprintf("%s %s%s%s", matchQuery, tags.PreTags, highlightPhrase, tags.PostTags)
 					suggestionValue := matchQuery + " " + highlightPhrase
 					// transform diacritics chars when comparing for uniqueness of predictive suggestions
 					if !suggestionsMap[replaceDiacritics(suggestionValue)] {
@@ -673,21 +673,6 @@ func parseHits(hits []ESDoc) []ESDoc {
 		results = append(results, highlightResults(hit))
 	}
 	return results
-}
-
-// Removes the punctuation from a string
-func strip(s string) string {
-	var result strings.Builder
-	for i := 0; i < len(s); i++ {
-		b := s[i]
-		if ('a' <= b && b <= 'z') ||
-			('A' <= b && b <= 'Z') ||
-			('0' <= b && b <= '9') ||
-			b == ' ' {
-			result.WriteByte(b)
-		}
-	}
-	return result.String()
 }
 
 // Util method to extract the fields from elasticsearch source object

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -425,7 +425,7 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 				stemmedHighlightPhrase := strings.Join(stemmedTokens(highlightPhrase, language), " ")
 				ignore := false
 				for _, qToken := range stemmedQvls {
-					if strings.EqualFold(stemmedHighlightPhrase, qToken) {
+					if strings.Contains(stemmedHighlightPhrase, qToken) {
 						ignore = true
 					}
 				}
@@ -453,7 +453,7 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 				stemmedHighlightPhrase := strings.Join(stemmedTokens(highlightPhrase, language), " ")
 				ignore := false
 				for _, qToken := range stemmedQvls {
-					if strings.EqualFold(stemmedHighlightPhrase, qToken) {
+					if strings.Contains(stemmedHighlightPhrase, qToken) {
 						ignore = true
 					}
 				}

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -1,86 +1,12 @@
 package querytranslate
 
 import (
-	"encoding/json"
 	"fmt"
-	"math"
 	"sort"
-	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/appbaseio/reactivesearch-api/util"
-	"github.com/bbalet/stopwords"
-	"github.com/kljensen/snowball"
-	"github.com/lithammer/fuzzysearch/fuzzy"
-	"github.com/microcosm-cc/bluemonday"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 )
-
-// Do this once for each unique policy, and use the policy for the life of the program
-// Policy creation/editing is not safe to use in multiple goroutines
-var p = bluemonday.StrictPolicy()
-
-type SuggestionType int
-
-const (
-	Index SuggestionType = iota
-	Popular
-	Recent
-	Promoted
-)
-
-// String is the implementation of Stringer interface that returns the string representation of SuggestionType type.
-func (o SuggestionType) String() string {
-	return [...]string{
-		"index",
-		"popular",
-		"recent",
-		"promoted",
-	}[o]
-}
-
-// UnmarshalJSON is the implementation of the Unmarshaler interface for unmarshaling SuggestionType type.
-func (o *SuggestionType) UnmarshalJSON(bytes []byte) error {
-	var suggestionType string
-	err := json.Unmarshal(bytes, &suggestionType)
-	if err != nil {
-		return err
-	}
-	switch suggestionType {
-	case Index.String():
-		*o = Index
-	case Popular.String():
-		*o = Popular
-	case Recent.String():
-		*o = Recent
-	case Promoted.String():
-		*o = Promoted
-	default:
-		return fmt.Errorf("invalid suggestion type encountered: %v", suggestionType)
-	}
-	return nil
-}
-
-// MarshalJSON is the implementation of the Marshaler interface for marshaling SuggestionType type.
-func (o SuggestionType) MarshalJSON() ([]byte, error) {
-	var suggestionType string
-	switch o {
-	case Index:
-		suggestionType = Index.String()
-	case Popular:
-		suggestionType = Popular.String()
-	case Recent:
-		suggestionType = Recent.String()
-	case Promoted:
-		suggestionType = Promoted.String()
-	default:
-		return nil, fmt.Errorf("invalid suggestion type encountered: %v", o)
-	}
-	return json.Marshal(suggestionType)
-}
 
 // SuggestionHIT represents the structure of the suggestion object in RS API response
 type SuggestionHIT struct {
@@ -173,389 +99,79 @@ type SuggestionsConfig struct {
 	Language                    *string
 }
 
-func stemmedTokens(source string, language string) []string {
-	tokens := strings.Split(source, " ")
-	var stemmedTokens []string
-	for _, token := range tokens {
-		// stem the token
-		stemmedToken, _ := snowball.Stem(token, language, false)
-		stemmedTokens = append(stemmedTokens, stemmedToken)
-	}
-	return stemmedTokens
-}
-
-// removeStopwords removes stopwords including considering the suggestions config
-func removeStopwords(value string, config SuggestionsConfig) string {
-	ln := "en"
-	if config.Language != nil && LanguagesToISOCode[*config.Language] != "" {
-		ln = LanguagesToISOCode[*config.Language]
-	}
-	var userStopwords []string
-	// load any custom stopwords the user has
-	// a highlighted phrase shouldn't be limited due to stopwords
-	if config.ApplyStopwords != nil && *config.ApplyStopwords {
-		// apply any custom stopwords
-		if config.Stopwords != nil {
-			userStopwords = *config.Stopwords
-		}
-	}
-	if len(userStopwords) > 0 {
-		stopwords.LoadStopWordsFromString(strings.Join(userStopwords, " "), ln, " ")
-	}
-	cleanContent := stopwords.CleanString(value, ln, true)
-	return NormalizeValue(cleanContent)
-}
-
-// NormalizeValue changes a query's value to remove special chars and spaces
-// e.g. Android - Black would be "android black"
-// e.g. "Wendy's burger  " would be "wendy burger"
-func NormalizeValue(value string) string {
-	// Trim the spaces and tokenize
-	tokenizedValue := strings.Split(strings.TrimSpace(value), " ")
-	var finalValue []string
-	for _, token := range tokenizedValue {
-		sT := SanitizeString(token)
-		if len(sT) > 0 {
-			finalValue = append(finalValue, strings.ToLower(sT))
-		}
-	}
-	return strings.ToLower(strings.TrimSpace(strings.Join(finalValue, " ")))
-}
-
-// findMatch matches the user query against the field value to return scores and matched tokens
-func findMatch(fieldValueRaw string, userQueryRaw string, config SuggestionsConfig) RankField {
-	// remove stopwords from fieldValue and userQuery
-	fieldValue := removeStopwords(fieldValueRaw, config)
-	userQuery := removeStopwords(userQueryRaw, config)
-	var rankField = RankField{
-		fieldValue:    fieldValue,
-		userQuery:     userQuery,
-		score:         0,
-		matchedTokens: nil,
-	}
-	stemLanguage := "english"
-	if config.Language != nil {
-		if util.Contains(StemLanguages, *config.Language) {
-			stemLanguage = *config.Language
-		}
-	}
-	fieldValues := strings.Split(fieldValue, " ")
-	stemmedFieldValues := stemmedTokens(fieldValue, stemLanguage)
-	stemmeduserQuery := stemmedTokens(userQuery, stemLanguage)
-	foundMatches := make([]bool, len(stemmeduserQuery))
-	for i, token := range stemmeduserQuery {
-
-		// eliminate single char tokens from consideration
-		if len(token) > 1 {
-			foundMatch := false
-			// start with the default distance of 1.0
-			bestDistance := 1.0
-			ranks := fuzzy.RankFindNormalizedFold(token, stemmedFieldValues)
-			var bestTarget string
-			for _, element := range ranks {
-				switch element.Distance {
-				case 0:
-					// Perfect match, we can skip iteration and just return
-					bestDistance = math.Min(0, bestDistance)
-					foundMatch = true
-					bestTarget = element.Target
-				case 1:
-					// 1 edit distance
-					bestDistance = math.Min(1.0, bestDistance)
-					foundMatch = true
-					if bestTarget == "" {
-						bestTarget = element.Target
-					}
-				}
-			}
-			matchIndex := sliceIndex(len(stemmedFieldValues), func(i int) bool {
-				return stemmedFieldValues[i] == bestTarget
-			})
-			if matchIndex != -1 {
-				rankField.matchedTokens = append(rankField.matchedTokens, fieldValues[matchIndex])
-			}
-			foundMatches[i] = foundMatch
-			// token of user query matched one of the tokens of field values
-			if foundMatch {
-				rankField.score += 1.0 - (bestDistance / 2)
-				// add score for a consecutive match
-				if i > 0 {
-					if foundMatches[i] && foundMatches[i-1] {
-						rankField.score += 0.1
-					}
-				}
-			}
-		}
-	}
-	return rankField
-}
-
-const preTags = `<b class="highlight">`
-const postTags = `</b>`
-
-type Tags struct {
-	PreTags  string
-	PostTags string
-}
-
-func getPredictiveSuggestionsTags(highlightConfig *map[string]interface{}) Tags {
-	var preTags = `<b class="highlight">`
-	var postTags = `</b>`
-
-	if highlightConfig != nil {
-		config := *highlightConfig
-		if config["pre_tags"] != nil {
-			tagsAsString, ok := config["pre_tags"].(string)
-			if ok {
-				preTags = tagsAsString
-			} else {
-				tagsAsArray, ok := config["pre_tags"].([]interface{})
-				if ok {
-					tags := []string{}
-					for _, tag := range tagsAsArray {
-						tagsAsString, ok := tag.(string)
-						if ok {
-							tags = append(tags, tagsAsString)
-						}
-					}
-					preTags = strings.Join(tags, "")
-				}
-			}
-		}
-		if config["post_tags"] != nil {
-			tagsAsString, ok := config["post_tags"].(string)
-			if ok {
-				postTags = tagsAsString
-			} else {
-				tagsAsArray, ok := config["post_tags"].([]interface{})
-				if ok {
-					tags := []string{}
-					for _, tag := range tagsAsArray {
-						tagsAsString, ok := tag.(string)
-						if ok {
-							tags = append(tags, tagsAsString)
-						}
-					}
-					postTags = strings.Join(tags, "")
-				}
-			}
-		}
+// getIndexSuggestions gets the index suggestions based on user query config and search engine response
+func getIndexSuggestions(config SuggestionsConfig, rawHits []ESDoc) []SuggestionHIT {
+	// before parsing any suggestions, normalize the query
+	config.Value = normalizeValue(config.Value)
+	// set priority to highlight fields if present
+	if len(config.HighlightField) != 0 {
+		config.DataFields = config.HighlightField
+	} else if len(config.DataFields) == 0 && len(rawHits) > 0 {
+		// extract fields from first hit source
+		config.DataFields = extractFieldsFromSource(rawHits[0].Source)
 	}
 
-	return Tags{
-		PreTags:  preTags,
-		PostTags: postTags,
+	// parse hits with highlighting
+	var parsedHits = make([]ESDoc, 0)
+	for _, hit := range rawHits {
+		parsedHits = append(parsedHits, addFieldHighlight(hit))
 	}
-}
 
-func getDefaultSuggestionsHighlight(query Query) map[string]interface{} {
-	highlightFields := make(map[string]interface{})
-	fields := query.HighlightField
-	if len(fields) == 0 {
-		// use data fields as highlighted field
-		dataFields := NormalizedDataFields(query.DataField, []float64{})
-		for _, v := range dataFields {
-			fields = append(fields, v.Field)
-		}
-	}
-	for _, v := range fields {
-		highlightFields[v] = make(map[string]interface{})
-	}
-	return map[string]interface{}{
-		"fields":    highlightFields,
-		"pre_tags":  preTags,
-		"post_tags": postTags,
-	}
-}
-
-func isMn(r rune) bool {
-	return unicode.Is(unicode.Mn, r) // Mn: nonspacing marks
-}
-
-// replaces diacritics with their equivalent
-func replaceDiacritics(query string) string {
-	t := transform.Chain(norm.NFD, transform.RemoveFunc(isMn), norm.NFC)
-	queryKey, _, _ := transform.String(t, query)
-	return queryKey
-}
-
-// populateDefaultSuggestions populates the default (i.e. non-predictive) suggestions using field values of each doc
-func populateDefaultSuggestions(
-	labelsList *[]string,
-	suggestionsList *[]SuggestionHIT,
-	docField DocField,
-	config SuggestionsConfig,
-) {
-	if !util.Contains(*labelsList, removeStopwords(ParseSuggestionLabel(docField.value, config.Language), config)) {
-		var url *string
-		if config.URLField != nil {
-			urlString, ok := docField.rawHit.Source[*config.URLField].(string)
-			if ok {
-				url = &urlString
-			}
-		}
-		var category *string
-		if config.CategoryField != nil {
-			categoryString, ok := docField.rawHit.Source[*config.CategoryField].(string)
-			if ok {
-				category = &categoryString
-			}
-		}
-		// stores the normalized field value to match agains the normalized query value
-		fieldValue := NormalizeValue(getTextFromHTML(docField.value))
-		// TODO: This won't work on query synonyms, need to account for that
-		rankField := findMatch(fieldValue, config.Value, config)
-		// helpful for debugging
-		// fmt.Println("query: ", config.Value, ", field value: ", fieldValue, ", match score: ", rankField.score, ", matched tokens: ", rankField.matchedTokens)
-		suggestion := SuggestionHIT{
-			Value:         fieldValue,
-			Label:         docField.value,
-			URL:           url,
-			Type:          Index,
-			Category:      category,
-			RSScore:       rankField.score,
-			MatchedTokens: rankField.matchedTokens,
-			// ES response properties
-			Id:     docField.rawHit.Id,
-			Index:  &docField.rawHit.Index,
-			Source: docField.rawHit.Source,
-			Score:  docField.rawHit.Score,
-		}
-
-		*labelsList = append(*labelsList, removeStopwords(ParseSuggestionLabel(docField.value, config.Language), config))
-		*suggestionsList = append(*suggestionsList, suggestion)
-	}
-}
-
-// extracts the string from HTML tags
-func getTextFromHTML(body string) string {
-
-	// The policy can then be used to sanitize lots of input and it is safe to use the policy in multiple goroutines
-	html := p.Sanitize(
-		body,
-	)
-
-	return html
-}
-
-// getPredictiveSuggestions creates predictive suggestions based on the default suggestions
-// What are predictive suggestions? Instead of displaying the entire field value as a suggestion (value may be too long to fit into the searchbox), they only display the next relevant words, preferrably as a suffix or as a prefix
-func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]SuggestionHIT) []SuggestionHIT {
+	// keep track of suggestions list
 	var suggestionsList = make([]SuggestionHIT, 0)
-	var suggestionsMap = make(map[string]bool)
-	if config.Value != "" {
-		tags := getPredictiveSuggestionsTags(config.HighlightConfig)
-		for _, suggestion := range *suggestions {
-			fieldValues := strings.Split(NormalizeValue(getTextFromHTML(suggestion.Label)), " ")
-			fvl := len(fieldValues)
-			queryValues := strings.Split(NormalizeValue(config.Value), " ")
-			suffixStarts := 0
-			prefixEnds := max(fvl-1, 0)
-			// helpful for debugging
-			// fmt.Println("predictive suggestion: ", ", query is: ", config.Value, ", field value is: ", strings.Join(fieldValues, " "))
-			for _, qToken := range queryValues {
-				matchIndex := sliceIndex(fvl, func(i int) bool { return strings.Contains(fieldValues[i], qToken) })
-				if matchIndex != -1 {
-					prefixEnds = min(prefixEnds, matchIndex-1)
-					suffixStarts = max(suffixStarts, matchIndex+1)
-				}
-			}
-			var matched = false
-			maxPredictedWords := 2
-			if config.MaxPredictedWords != nil {
-				maxPredictedWords = *config.MaxPredictedWords
-			}
-			// helpful for debugging
-			// fmt.Println("prefix ends: ", prefixEnds)
-			// fmt.Println("suffix starts: ", suffixStarts)
 
-			if suffixStarts > 0 {
-				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[suffixStarts:], " "), max(maxPredictedWords, 1), config)
-				// highlightPhrase can additionally not contain any matched tokens as they would duplicate
-				hltValues := strings.Split(highlightPhrase, " ")
-				ignore := false
-				for _, qToken := range queryValues {
-					if sliceIndex(len(hltValues), func(i int) bool { return hltValues[i] == qToken }) != -1 {
-						ignore = true
-					}
-				}
-				if !ignore && len(highlightPhrase) > 1 {
-					// helpful for debugging
-					// fmt.Println("in suffix: highlighted phrase is: ", highlightPhrase)
-					var matchQuery string
-					// case where we replace the matching field value query in place of the actual query
-					if sliceIndex(len(queryValues), func(i int) bool { return strings.Contains(fieldValues[prefixEnds+1], queryValues[i]) }) != -1 {
-						matchQuery = strings.Join(fieldValues[prefixEnds+1:suffixStarts], " ")
-					} else {
-						matchQuery = config.Value
-					}
-					suggestionPhrase := fmt.Sprintf("%s %s%s%s", matchQuery, tags.PreTags, highlightPhrase, tags.PostTags)
-					suggestionValue := matchQuery + " " + highlightPhrase
-					// transform diacritics chars when comparing for uniqueness of predictive suggestions
-					if !suggestionsMap[replaceDiacritics(suggestionValue)] {
-						predictiveSuggestion := suggestion
-						predictiveSuggestion.Label = suggestionPhrase
-						predictiveSuggestion.Value = suggestionValue
-						suggestionsList = append(suggestionsList, predictiveSuggestion)
-						// update map
-						suggestionsMap[replaceDiacritics(suggestionValue)] = true
-						matched = true
-					}
-				}
-			}
-			if prefixEnds >= 0 && !matched {
-				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[:prefixEnds+1], " "), max(maxPredictedWords, 1), config)
-				// highlightPhrase can additionally not contain any matched tokens as they would duplicate
-				hltValues := strings.Split(highlightPhrase, " ")
-				ignore := false
-				for _, qToken := range queryValues {
-					if sliceIndex(len(hltValues), func(i int) bool { return hltValues[i] == qToken }) != -1 {
-						ignore = true
-					}
-				}
-				// helpful for debugging
-				// fmt.Println("in prefix: highlighted phrase is: ", highlightPhrase)
-				if !ignore && len(highlightPhrase) > 1 {
-					var matchQuery string
-					// case where we replace the matching field value query in place of the actual query
-					if suffixStarts > 0 && sliceIndex(len(queryValues), func(i int) bool { return strings.Contains(fieldValues[suffixStarts-1], queryValues[i]) }) != -1 {
-						matchQuery = strings.Join(fieldValues[prefixEnds+1:suffixStarts], " ")
-					} else {
-						matchQuery = config.Value
-					}
-					suggestionPhrase := tags.PreTags + highlightPhrase + tags.PostTags + " " + matchQuery
-					suggestionValue := highlightPhrase + " " + matchQuery
-					matched = true
-					// transform diacritics chars when comparing for uniqueness of predictive suggestions
-					if !suggestionsMap[replaceDiacritics(suggestionValue)] {
-						predictiveSuggestion := suggestion
-						predictiveSuggestion.Label = suggestionPhrase
-						predictiveSuggestion.Value = suggestionValue
-						suggestionsList = append(suggestionsList, predictiveSuggestion)
-						// update map
-						suggestionsMap[replaceDiacritics(suggestionValue)] = true
-						matched = true
-					}
-				}
+	// keep track of suggestions label, label must be unique
+	var labelsList = make([]string, 0)
+
+	getDefaultSuggestions(config, parsedHits, &suggestionsList, &labelsList)
+
+	// sort suggestions based on the rank
+	// First priority is given to the _rs_score
+	// Second priority is given to the _score
+	sort.SliceStable(suggestionsList, func(i, j int) bool {
+		if suggestionsList[i].RSScore > suggestionsList[j].RSScore {
+			return true
+		}
+		if suggestionsList[i].RSScore == suggestionsList[j].RSScore {
+			return suggestionsList[i].Score > suggestionsList[j].Score
+		}
+		return false
+	})
+
+	if config.EnablePredictiveSuggestions != nil && *config.EnablePredictiveSuggestions {
+		suggestionsList = getPredictiveSuggestions(config, &suggestionsList)
+	}
+
+	if config.ShowDistinctSuggestions != nil && *config.ShowDistinctSuggestions {
+		// keep track of document ids for suggestions
+		var idMap = make(map[interface{}]bool)
+		filteredSuggestions := make([]SuggestionHIT, 0)
+		for _, suggestion := range suggestionsList {
+			if !idMap[suggestion.Id] {
+				filteredSuggestions = append(filteredSuggestions, suggestion)
+				idMap[suggestion.Id] = true
 			}
 		}
+		return filteredSuggestions
 	}
 	return suggestionsList
 }
 
-// getHighlightedPhrase takes a candidate phrase (prefix or suffix) of the field value based on the match found with the search query.
-// It returns up to maxTokens length of phrase ignoring for any stopwords in between
-func getHighlightedPhrase(candidateWord string, maxTokens int, config SuggestionsConfig) string {
-	var wordsPhrase []string
-	if config.ApplyStopwords != nil && *config.ApplyStopwords {
-		wordsPhrase = strings.Split(removeStopwords(candidateWord, config), " ")
-	} else {
-		wordsPhrase = strings.Split(candidateWord, " ")
+// getDefaultSuggestions traverses over ES docs and checks for a suggestion match against each field from the query
+// A suggestion is considered matching if
+func getDefaultSuggestions(
+	config SuggestionsConfig,
+	parsedHits []ESDoc,
+	suggestionsList *[]SuggestionHIT,
+	labelsList *[]string,
+) {
+	// iterate over ES docs
+	for _, hit := range parsedHits {
+		// iterate over fields
+		for _, field := range config.DataFields {
+			parseResponseTree(hit.ParsedSource, field, suggestionsList, labelsList, hit, config)
+		}
 	}
-	if len(wordsPhrase) > maxTokens {
-		return strings.TrimSpace(strings.Join(wordsPhrase[:maxTokens], " "))
-	}
-	return strings.TrimSpace(strings.Join(wordsPhrase, " "))
 }
 
 // parseResponseTree parses the suggestions from a response tree
@@ -629,220 +245,256 @@ func parseResponseTree(
 	}
 }
 
-// getDefaultSuggestions traverses over ES docs and checks for a suggestion match against each field from the query
-// A suggestion is considered matching if
-func getDefaultSuggestions(
-	config SuggestionsConfig,
-	parsedHits []ESDoc,
-	suggestionsList *[]SuggestionHIT,
+// populateDefaultSuggestions populates the default (i.e. non-predictive) suggestions using field values of each doc
+func populateDefaultSuggestions(
 	labelsList *[]string,
+	suggestionsList *[]SuggestionHIT,
+	docField DocField,
+	config SuggestionsConfig,
 ) {
-	// iterate over ES docs
-	for _, hit := range parsedHits {
-		// iterate over fields
-		for _, field := range config.DataFields {
-			parseResponseTree(hit.ParsedSource, field, suggestionsList, labelsList, hit, config)
-		}
-	}
-}
-
-// Highlights the fields by replacing the actual value with markup
-func highlightResults(source ESDoc) ESDoc {
-	source.ParsedSource = make(map[string]interface{})
-	// clone map
-	for k, v := range source.Source {
-		source.ParsedSource[k] = v
-	}
-
-	if source.Highlight != nil {
-		for highlightItem, highlightedValue := range source.Highlight {
-			highlightValueArray, ok := highlightedValue.([]interface{})
-			if ok && len(highlightValueArray) > 0 {
-				highlightValue := highlightValueArray[0]
-				source.ParsedSource[highlightItem] = highlightValue
+	if !util.Contains(*labelsList, parseSuggestionLabel(docField.value, config)) {
+		var url *string
+		if config.URLField != nil {
+			urlString, ok := docField.rawHit.Source[*config.URLField].(string)
+			if ok {
+				url = &urlString
 			}
 		}
+		var category *string
+		if config.CategoryField != nil {
+			categoryString, ok := docField.rawHit.Source[*config.CategoryField].(string)
+			if ok {
+				category = &categoryString
+			}
+		}
+		// stores the normalized field value to match agains the normalized query value
+		fieldValue := normalizeValue(getTextFromHTML(docField.value))
+		// TODO: This won't work on query synonyms, need to account for that
+		rankField := findMatch(fieldValue, config.Value, config)
+		// helpful for debugging
+		// fmt.Println("query: ", config.Value, ", field value: ", fieldValue, ", match score: ", rankField.score, ", matched tokens: ", rankField.matchedTokens)
+		suggestion := SuggestionHIT{
+			Value:         fieldValue,
+			Label:         docField.value,
+			URL:           url,
+			Type:          Index,
+			Category:      category,
+			RSScore:       rankField.score,
+			MatchedTokens: rankField.matchedTokens,
+			// ES response properties
+			Id:     docField.rawHit.Id,
+			Index:  &docField.rawHit.Index,
+			Source: docField.rawHit.Source,
+			Score:  docField.rawHit.Score,
+		}
+
+		*labelsList = append(*labelsList, parseSuggestionLabel(docField.value, config))
+		*suggestionsList = append(*suggestionsList, suggestion)
 	}
-	return source
 }
 
-// To parse the elasticsearch hits with highlighted fields
-func parseHits(hits []ESDoc) []ESDoc {
-	var results = make([]ESDoc, 0)
-	for _, hit := range hits {
-		results = append(results, highlightResults(hit))
-	}
-	return results
+const preTags = `<b class="highlight">`
+const postTags = `</b>`
+
+type Tags struct {
+	PreTags  string
+	PostTags string
 }
 
-// Util method to extract the fields from elasticsearch source object
-// It can handle nested objects and arrays too.
-// Example 1:
-// Input: { a: 1, b: { b_1: 2, b_2: 3}}
-// Output: ['a', 'b.b_1', 'b.b_2']
-// Example 2:
-// Input: { a: 1, b: [{c: 1}, {d: 2}, {c: 3}]}
-// Output: ['a', 'b.c', 'b.d']
-func getFields(source interface{}, prefix string) map[string]interface{} {
-	dataFields := make(map[string]interface{})
-	sourceAsMap, ok := source.(map[string]interface{})
-	if ok {
-		for field := range sourceAsMap {
-			var key string
-			if prefix != "" {
-				key = prefix + "." + field
+// getPredictiveSuggestionsTags parses the highlightConfig (if specified)
+// and returns the tags
+func getPredictiveSuggestionsTags(highlightConfig *map[string]interface{}) Tags {
+	var preTags = `<b class="highlight">`
+	var postTags = `</b>`
+
+	if highlightConfig != nil {
+		config := *highlightConfig
+		if config["pre_tags"] != nil {
+			tagsAsString, ok := config["pre_tags"].(string)
+			if ok {
+				preTags = tagsAsString
 			} else {
-				key = field
-			}
-			if sourceAsMap[field] != nil {
-				mapValue, ok := sourceAsMap[field].(map[string]interface{})
+				tagsAsArray, ok := config["pre_tags"].([]interface{})
 				if ok {
-					mergeMaps(dataFields, getFields(mapValue, key))
-				} else {
-					mapValueAsArray, ok := sourceAsMap[field].([]interface{})
-					if ok {
-						mergeMaps(dataFields, getFields(mapValueAsArray, key))
-					} else {
-						mergeMaps(dataFields, map[string]interface{}{
-							key: true,
-						})
-					}
-				}
-			}
-		}
-	} else {
-		sourceAsArray, ok := source.([]interface{})
-		if ok {
-			for field := range sourceAsArray {
-				var key string
-				if prefix != "" {
-					key = prefix
-				} else {
-					key = strconv.Itoa(field)
-				}
-				if sourceAsArray[field] != nil {
-					mapValue, ok := sourceAsArray[field].(map[string]interface{})
-					if ok {
-						mergeMaps(dataFields, getFields(mapValue, key))
-					} else {
-						mapValueAsArray, ok := sourceAsArray[field].([]interface{})
+					tags := []string{}
+					for _, tag := range tagsAsArray {
+						tagsAsString, ok := tag.(string)
 						if ok {
-							mergeMaps(dataFields, getFields(mapValueAsArray, key))
-						} else {
-							mergeMaps(dataFields, map[string]interface{}{
-								key: true,
-							})
+							tags = append(tags, tagsAsString)
 						}
 					}
+					preTags = strings.Join(tags, "")
+				}
+			}
+		}
+		if config["post_tags"] != nil {
+			tagsAsString, ok := config["post_tags"].(string)
+			if ok {
+				postTags = tagsAsString
+			} else {
+				tagsAsArray, ok := config["post_tags"].([]interface{})
+				if ok {
+					tags := []string{}
+					for _, tag := range tagsAsArray {
+						tagsAsString, ok := tag.(string)
+						if ok {
+							tags = append(tags, tagsAsString)
+						}
+					}
+					postTags = strings.Join(tags, "")
 				}
 			}
 		}
 	}
 
-	return dataFields
+	return Tags{
+		PreTags:  preTags,
+		PostTags: postTags,
+	}
 }
 
-func extractFieldsFromSource(source map[string]interface{}) []string {
-	dataFields := []string{}
-	var sourceAsInterface interface{} = source
-	dataFieldsMap := getFields(sourceAsInterface, "")
-	for k := range dataFieldsMap {
-		dataFields = append(dataFields, k)
+// getDefaultSuggestionsHighlight returns default suggestion highlight settings, i.e. fields
+// and tags to apply based on the highlightField and dataField
+// properties
+func getDefaultSuggestionsHighlight(query Query) map[string]interface{} {
+	highlightFields := make(map[string]interface{})
+	fields := query.HighlightField
+	if len(fields) == 0 {
+		// use data fields as highlighted field
+		dataFields := NormalizedDataFields(query.DataField, []float64{})
+		for _, v := range dataFields {
+			fields = append(fields, v.Field)
+		}
 	}
-	return dataFields
+	for _, v := range fields {
+		highlightFields[v] = make(map[string]interface{})
+	}
+	return map[string]interface{}{
+		"fields":    highlightFields,
+		"pre_tags":  preTags,
+		"post_tags": postTags,
+	}
 }
 
-// getIndexSuggestions gets the index suggestions based on user query config and search engine response
-func getIndexSuggestions(config SuggestionsConfig, rawHits []ESDoc) []SuggestionHIT {
-	// before parsing any suggestions, normalize the query
-	config.Value = NormalizeValue(config.Value)
-	// set priority to highlight fields if present
-	if len(config.HighlightField) != 0 {
-		config.DataFields = config.HighlightField
-	} else if len(config.DataFields) == 0 && len(rawHits) > 0 {
-		// extract fields from first hit source
-		config.DataFields = extractFieldsFromSource(rawHits[0].Source)
-	}
-
-	// parse hits
-	parsedHits := parseHits(rawHits)
-	// keep track of suggestions list
+// getPredictiveSuggestions creates predictive suggestions based on the default suggestions
+// What are predictive suggestions? Instead of displaying the entire field value as a suggestion (value may be too long to fit into the searchbox), they only display the next relevant words, preferrably as a suffix or as a prefix
+func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]SuggestionHIT) []SuggestionHIT {
 	var suggestionsList = make([]SuggestionHIT, 0)
+	var suggestionsMap = make(map[string]bool)
+	if config.Value != "" {
+		tags := getPredictiveSuggestionsTags(config.HighlightConfig)
+		for _, suggestion := range *suggestions {
+			fieldValues := strings.Split(normalizeValue(getTextFromHTML(suggestion.Label)), " ")
+			fvl := len(fieldValues)
+			queryValues := strings.Split(normalizeValue(config.Value), " ")
+			suffixStarts := 0
+			prefixEnds := max(fvl-1, 0)
+			// helpful for debugging
+			// fmt.Println("predictive suggestion: ", ", query is: ", config.Value, ", field value is: ", strings.Join(fieldValues, " "))
+			for _, qToken := range queryValues {
+				matchIndex := sliceIndex(fvl, func(i int) bool { return strings.Contains(fieldValues[i], qToken) })
+				if matchIndex != -1 {
+					prefixEnds = min(prefixEnds, matchIndex-1)
+					suffixStarts = max(suffixStarts, matchIndex+1)
+				}
+			}
+			var matched = false
+			maxPredictedWords := 2
+			if config.MaxPredictedWords != nil {
+				maxPredictedWords = *config.MaxPredictedWords
+			}
+			// helpful for debugging
+			// fmt.Println("prefix ends: ", prefixEnds)
+			// fmt.Println("suffix starts: ", suffixStarts)
 
-	// keep track of suggestions label, label must be unique
-	var labelsList = make([]string, 0)
-
-	getDefaultSuggestions(config, parsedHits, &suggestionsList, &labelsList)
-
-	// sort suggestions based on the rank
-	// First priority is given to the _rs_score
-	// Second priority is given to the _score
-	sort.SliceStable(suggestionsList, func(i, j int) bool {
-		if suggestionsList[i].RSScore > suggestionsList[j].RSScore {
-			return true
-		}
-		if suggestionsList[i].RSScore == suggestionsList[j].RSScore {
-			return suggestionsList[i].Score > suggestionsList[j].Score
-		}
-		return false
-	})
-
-	if config.EnablePredictiveSuggestions != nil && *config.EnablePredictiveSuggestions {
-		suggestionsList = getPredictiveSuggestions(config, &suggestionsList)
-	}
-
-	if config.ShowDistinctSuggestions != nil && *config.ShowDistinctSuggestions {
-		// keep track of document ids for suggestions
-		var idMap = make(map[interface{}]bool)
-		filteredSuggestions := make([]SuggestionHIT, 0)
-		for _, suggestion := range suggestionsList {
-			if !idMap[suggestion.Id] {
-				filteredSuggestions = append(filteredSuggestions, suggestion)
-				idMap[suggestion.Id] = true
+			if suffixStarts > 0 {
+				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[suffixStarts:], " "), max(maxPredictedWords, 1), config)
+				// highlightPhrase can additionally not contain any matched tokens as they would duplicate
+				hltValues := strings.Split(highlightPhrase, " ")
+				ignore := false
+				for _, qToken := range queryValues {
+					if sliceIndex(len(hltValues), func(i int) bool { return hltValues[i] == qToken }) != -1 {
+						ignore = true
+					}
+				}
+				if !ignore && len(highlightPhrase) > 1 {
+					// helpful for debugging
+					// fmt.Println("in suffix: highlighted phrase is: ", highlightPhrase)
+					var matchQuery string
+					// case where we replace the matching field value query in place of the actual query
+					if sliceIndex(len(queryValues), func(i int) bool { return strings.Contains(fieldValues[prefixEnds+1], queryValues[i]) }) != -1 && suffixStarts-(prefixEnds+1) <= 2 {
+						matchQuery = strings.Join(fieldValues[prefixEnds+1:suffixStarts], " ")
+						if isSimilar(matchQuery, config.Value, config) {
+							matchQuery = config.Value
+						}
+					} else {
+						matchQuery = config.Value
+					}
+					suggestionPhrase := fmt.Sprintf("%s %s%s%s", matchQuery, tags.PreTags, highlightPhrase, tags.PostTags)
+					suggestionValue := matchQuery + " " + highlightPhrase
+					// transform diacritics chars when comparing for uniqueness of predictive suggestions
+					if !suggestionsMap[replaceDiacritics(suggestionValue)] {
+						predictiveSuggestion := suggestion
+						predictiveSuggestion.Label = suggestionPhrase
+						predictiveSuggestion.Value = suggestionValue
+						suggestionsList = append(suggestionsList, predictiveSuggestion)
+						// update map
+						suggestionsMap[replaceDiacritics(suggestionValue)] = true
+						matched = true
+					}
+				}
+			}
+			if prefixEnds >= 0 && !matched {
+				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[:prefixEnds+1], " "), max(maxPredictedWords, 1), config)
+				// highlightPhrase can additionally not contain any matched tokens as they would duplicate
+				hltValues := strings.Split(highlightPhrase, " ")
+				ignore := false
+				for _, qToken := range queryValues {
+					if sliceIndex(len(hltValues), func(i int) bool { return hltValues[i] == qToken }) != -1 {
+						ignore = true
+					}
+				}
+				// helpful for debugging
+				// fmt.Println("in prefix: highlighted phrase is: ", highlightPhrase)
+				if !ignore && len(highlightPhrase) > 1 {
+					var matchQuery string
+					// case where we replace the matching field value query in place of the actual query
+					if suffixStarts > 0 && sliceIndex(len(queryValues), func(i int) bool { return strings.Contains(fieldValues[suffixStarts-1], queryValues[i]) }) != -1 && suffixStarts-(prefixEnds+1) <= 2 {
+						matchQuery = strings.Join(fieldValues[prefixEnds+1:suffixStarts], " ")
+					} else {
+						matchQuery = config.Value
+					}
+					suggestionPhrase := tags.PreTags + highlightPhrase + tags.PostTags + " " + matchQuery
+					suggestionValue := highlightPhrase + " " + matchQuery
+					matched = true
+					// transform diacritics chars when comparing for uniqueness of predictive suggestions
+					if !suggestionsMap[replaceDiacritics(suggestionValue)] {
+						predictiveSuggestion := suggestion
+						predictiveSuggestion.Label = suggestionPhrase
+						predictiveSuggestion.Value = suggestionValue
+						suggestionsList = append(suggestionsList, predictiveSuggestion)
+						// update map
+						suggestionsMap[replaceDiacritics(suggestionValue)] = true
+						matched = true
+					}
+				}
 			}
 		}
-		return filteredSuggestions
 	}
 	return suggestionsList
 }
 
-// Removes the extra spaces from a string
-func RemoveSpaces(str string) string {
-	return strings.Join(strings.Fields(str), " ")
-}
-
-// SanitizeString removes special chars and spaces from a string
-func SanitizeString(str string) string {
-	// remove extra spaces
-	s := str
-	specialChars := []string{"'", "/", "{", "(", "[", "-", "+", ".", "^", ":", ",", "]", ")",
-		"}"}
-	// Remove special characters
-	for _, c := range specialChars {
-		s = strings.ReplaceAll(s, c, "")
-	}
-	return RemoveSpaces(s)
-}
-
-// Returns the parsed suggestion label to be compared for duplicate suggestions
-func ParseSuggestionLabel(label string, language *string) string {
-	// trim spaces
-	parsedLabel := RemoveSpaces(label)
-	// convert to lower case
-	parsedLabel = strings.ToLower(parsedLabel)
-	stemLanguage := "english"
-	if language != nil {
-		if util.Contains(StemLanguages, *language) {
-			stemLanguage = *language
-		}
-	}
-	// stem word
-	stemmed, err := snowball.Stem(parsedLabel, stemLanguage, true)
-	if err != nil {
-		log.Errorln(logTag, ":", err)
+// getHighlightedPhrase takes a candidate phrase (prefix or suffix) of the field value based on the match found with the search query.
+// It returns up to maxTokens length of phrase ignoring for any stopwords in between
+func getHighlightedPhrase(candidateWord string, maxTokens int, config SuggestionsConfig) string {
+	var wordsPhrase []string
+	if config.ApplyStopwords != nil && *config.ApplyStopwords {
+		wordsPhrase = strings.Split(removeStopwords(candidateWord, config), " ")
 	} else {
-		parsedLabel = stemmed
+		wordsPhrase = strings.Split(candidateWord, " ")
 	}
-	// remove stopwords
-	return RemoveSpaces(parsedLabel)
+	if len(wordsPhrase) > maxTokens {
+		return strings.TrimSpace(strings.Join(wordsPhrase[:maxTokens], " "))
+	}
+	return strings.TrimSpace(strings.Join(wordsPhrase, " "))
 }

--- a/plugins/querytranslate/suggestions_test.go
+++ b/plugins/querytranslate/suggestions_test.go
@@ -196,8 +196,8 @@ func TestPredictiveSuggestions(t *testing.T) {
 		}, &suggestions)
 		So(predictiveSuggestions, ShouldResemble, []SuggestionHIT{
 			{
-				Value: "batman sons",
-				Label: "batman <b class=\"highlight\">sons</b>",
+				Value: "bat sons",
+				Label: "bat <b class=\"highlight\">sons</b>",
 			},
 		})
 	})
@@ -219,8 +219,8 @@ func TestPredictiveSuggestions(t *testing.T) {
 		}, &suggestions)
 		So(predictiveSuggestions, ShouldResemble, []SuggestionHIT{
 			{
-				Value: "batman sons",
-				Label: "batman <b class=\"highlight\">sons</b>",
+				Value: "bat sons",
+				Label: "bat <b class=\"highlight\">sons</b>",
 			},
 		})
 	})

--- a/plugins/querytranslate/suggestions_test.go
+++ b/plugins/querytranslate/suggestions_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHighlightResults(t *testing.T) {
 	Convey("highlight results: with highlight field", t, func() {
-		So(highlightResults(ESDoc{
+		So(addFieldHighlight(ESDoc{
 			Source: map[string]interface{}{
 				"title":       "Harry Potter Collection",
 				"description": "desc1",
@@ -36,7 +36,7 @@ func TestHighlightResults(t *testing.T) {
 		})
 	})
 	Convey("highlight results: without highlight field", t, func() {
-		So(highlightResults(ESDoc{
+		So(addFieldHighlight(ESDoc{
 			Source: map[string]interface{}{
 				"title":       "Harry Potter Collection",
 				"description": "desc1",
@@ -316,6 +316,8 @@ func TestExtractFieldsFromSource(t *testing.T) {
 func TestParseSuggestionLabel(t *testing.T) {
 	Convey("with spaces", t, func() {
 		ln := "english"
-		So(ParseSuggestionLabel(" pizzas ", &ln), ShouldResemble, "pizza")
+		So(parseSuggestionLabel(" pizzas ", SuggestionsConfig{
+			Language: &ln,
+		}), ShouldResemble, "pizza")
 	})
 }

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -42,6 +42,14 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 			return "", errors.New("field 'dataField' can not have multiple fields for 'term' or 'geo' queries")
 		}
 
+		// Normalize query value for search and suggestion types of queries
+		if query.Type == Search || query.Type == Suggestion {
+			if query.Value != nil {
+				// set the updated value
+				rsQuery.Query[queryIndex].Value = normalizeQueryValue(query.Value)
+			}
+		}
+
 		// Parse synonyms fields if `EnableSynonyms` is set to `false`
 		if (query.Type == Search || query.Type == Suggestion) && query.EnableSynonyms != nil && !*query.EnableSynonyms {
 			var normalizedDataFields = []string{}

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -568,7 +568,7 @@ func (query *Query) getQuery(rsQuery RSQuery) (*interface{}, map[string]interfac
 func getFilteredOptions(options map[string]interface{}) map[string]interface{} {
 	filteredOptions := make(map[string]interface{})
 	for k, v := range options {
-		if !isExist(EXCEPTION_KEYS_IN_QUERY, k) {
+		if !util.IsExists(k, EXCEPTION_KEYS_IN_QUERY) {
 			filteredOptions[k] = v
 		}
 	}
@@ -626,16 +626,6 @@ func createBoolQuery(operation string, query interface{}) *map[string]interface{
 
 // To check if an item is present in a slice
 func contains(s []interface{}, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
-// To check if an item is present in a slice
-func isExist(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
 			return true
@@ -743,7 +733,7 @@ func ParseDataFieldToString(dataFieldAsMap map[string]interface{}) *DataField {
 // - Array of `DataField` struct
 // - Array of strings and `DataField` struct
 //
-// The following method normalizes the dataField input into a array of strings
+// The following function normalizes the dataField input into a array of strings
 // It also supports the fieldWeights in old format
 func NormalizedDataFields(dataField interface{}, fieldWeights []float64) []DataField {
 	dataFieldAsString, ok := dataField.(string)
@@ -993,6 +983,7 @@ func getTextFromHTML(body string) string {
 }
 
 // findMatch matches the user query against the field value to return scores and matched tokens
+// This supports fuzzy matching in addition to normalized matching (i.e. after stopwords removal and stemming)
 func findMatch(fieldValueRaw string, userQueryRaw string, config SuggestionsConfig) RankField {
 	// remove stopwords from fieldValue and userQuery
 	fieldValue := removeStopwords(fieldValueRaw, config)
@@ -1013,8 +1004,8 @@ func findMatch(fieldValueRaw string, userQueryRaw string, config SuggestionsConf
 	stemmedFieldValues := stemmedTokens(fieldValue, stemLanguage)
 	stemmeduserQuery := stemmedTokens(userQuery, stemLanguage)
 	foundMatches := make([]bool, len(stemmeduserQuery))
-	for i, token := range stemmeduserQuery {
 
+	for i, token := range stemmeduserQuery {
 		// eliminate single char tokens from consideration
 		if len(token) > 1 {
 			foundMatch := false
@@ -1079,7 +1070,7 @@ func extractFieldsFromSource(source map[string]interface{}) []string {
 }
 
 // getFields is used by extractFieldsFromSource to recursively extract
-// fields from
+// fields from the hit or a sub-part of the hit response tree
 func getFields(source interface{}, prefix string) map[string]interface{} {
 	dataFields := make(map[string]interface{})
 	sourceAsMap, ok := source.(map[string]interface{})


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

This PR improves precision of suggestions API response:

- Adds singular/plural request transformation
- Improved detection of duplicate suggestion values
- Use stemming while comparing user query with response hits

Also includes the following bug fixes:
- Fixes a bug with highlighting tags not being returned correctly
- Fix bug in use of stemmed token util function for an unsupported language
- Fix bug in use of remove stopwords util function which would've stripped digits

Refactors suggestion code into: 
- `suggestions.go` (everything directly related to suggestions parsing)
- `util.go` (everything indirectly related to suggestions parsing and possibly reusable in other areas)

#### What should your reviewer look out for in this PR?

- All unit test cases pass
- This is additionally tested manually (for subjective precision / recall evaluation) using a Postman based test suite
