### PR TITLE
Use ES Client to get Index Mapping call

### DIFF
--- a/util/migration.go
+++ b/util/migration.go
@@ -57,7 +57,7 @@ type IndexMappingResponse map[string]interface{}
 // expected to be handled by the calling function.
 func GetIndexMapping(indexName string, ctx context.Context) (resp IndexMappingResponse, err error) {
 	// Keep a constant variable to store the URL
-	MappingBaseURL := GetESURL() + "/%s/_mapping"
+	MappingBaseURL := "/%s/_mapping"
 
 	// Create a perform request struct
 	requestOptions := es7.PerformRequestOptions{

--- a/util/migration.go
+++ b/util/migration.go
@@ -1,12 +1,10 @@
 package util
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	es7 "github.com/olivere/elastic/v7"
 )
 
 type Error struct {
@@ -41,7 +39,11 @@ func AddMigrationScript(migration Migration) {
 type IndexMappingResponse map[string]interface{}
 
 // Fetch the index mapping manually using the following function
-// Make the request directly and return the response accordingly.
+// Make the request using an es7 client method that allows direct
+// requests. Using that gives us the addition of automatic request
+// retries in case the first request fails (due to ES not being
+// available?)
+//
 // We will extract the unstructured JSON data from the endpoint
 // and parse it to a map so that it can be directly used.
 //
@@ -52,29 +54,26 @@ type IndexMappingResponse map[string]interface{}
 // occurs while extracting the JSON data. There will be no verbose
 // if the error occurs while hitting the endpoint. Those errors are
 // expected to be handled by the calling function.
-func GetIndexMapping(indexName string) (resp IndexMappingResponse, err error) {
+func GetIndexMapping(indexName string, ctx context.Context) (resp IndexMappingResponse, err error) {
 	// Keep a constant variable to store the URL
 	MappingBaseURL := GetESURL() + "/%s/_mapping"
+
+	// Create a perform request struct
+	requestOptions := es7.PerformRequestOptions{
+		Method: "GET",
+		Path:   MappingBaseURL,
+	}
 
 	// Declare the mapping response variable
 	var data IndexMappingResponse
 
-	response, err := http.Get(fmt.Sprintf(MappingBaseURL, indexName))
+	response, err := GetClient7().PerformRequest(ctx, requestOptions)
 
 	if err != nil {
 		return data, err
 	}
 
-	defer response.Body.Close()
-
-	// Read the body into bytes and try to unmarshall
-	// into JSON data.
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		log.Errorln("error while reading JSON data: ", err)
-		return data, err
-	}
-
-	json.Unmarshal(body, &data)
+	// Unmarshall the JSON data
+	err = json.Unmarshal(response.Body, &data)
 	return data, err
 }

--- a/util/migration.go
+++ b/util/migration.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	es7 "github.com/olivere/elastic/v7"
 )
@@ -61,7 +62,7 @@ func GetIndexMapping(indexName string, ctx context.Context) (resp IndexMappingRe
 	// Create a perform request struct
 	requestOptions := es7.PerformRequestOptions{
 		Method: "GET",
-		Path:   MappingBaseURL,
+		Path:   fmt.Sprintf(MappingBaseURL, indexName),
 	}
 
 	// Declare the mapping response variable


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

This changes the get Index mapping code to make sure the code uses the es7 client to make the calls to the API. This has the advantage of retries in case the first call fails. This is useful when Elastic Search might not be available right away but would be after a few times or situations similar to this.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
