### PR TITLE
fix(suggestions): fixes a post-processing bug with concurrent map access

### DIFF
--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -394,8 +394,9 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 			normQuery := normalizeValue(config.Value)
 			queryValues := strings.Split(normQuery, " ")
 			// remove stopwords as long as query itself isn't completely removed
-			if removeStopwords(normQuery, config) != "" {
-				queryValues = strings.Split(removeStopwords(normQuery, config), " ")
+			removedStopwords := removeStopwords(normQuery, config)
+			if removedStopwords != "" {
+				queryValues = strings.Split(removedStopwords, " ")
 			}
 			stemmedQvls := stemmedTokens(strings.Join(queryValues, " "), language)
 			suffixStarts := 0


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

- Instead of relying on stopwords package to load the custom stopwords per request, we will handle removal of custom stopwords in the code itself
- This bug can cause a server crash when processing concurrent requests

#### Which issue(s) does this PR fix?

The fix was tested using this CSB: https://codesandbox.io/s/elated-night-21zm3?file=/script.js:343-364.

Relevant stacktrace from a server crash that this PR addresses:

```
fatal error: concurrent map writes

goroutine 6428 [running]:
runtime.throw(0x7f1c3df83284, 0x15)
        /usr/local/go/src/runtime/panic.go:1117 +0x74 fp=0xc000fb8748 sp=0xc000fb8718 pc=0x7f1c3d5e0cd4
runtime.mapassign_faststr(0xe61f80, 0xc0001a77d0, 0xc0003e66aa, 0x1, 0xc00bbd0988)
        /usr/local/go/src/runtime/map_faststr.go:211 +0x41e fp=0xc000fb87b0 sp=0xc000fb8748 pc=0x7f1c3d5bec5e
github.com/bbalet/stopwords.LoadStopWordsFromString(0xc0003e66a6, 0x5, 0x7f1c3df660a1, 0x2, 0x7f1c3e067578, 0x1)
        /home/centos/go/pkg/mod/github.com/bbalet/stopwords@v1.0.0/custom.go:74 +0x9db fp=0xc000fb8830 sp=0xc000fb87b0 pc=0x7f1c3deed93b
github.com/appbaseio/reactivesearch-api/plugins/querytranslate.removeStopwords(0xc011327b90, 0x90, 0xc010c38520, 0x2, 0x2, 0xc0003e66b0, 0xc, 0xc00c493278, 0xc005464870, 0xc00c493290, ...)
        /home/centos/go/pkg/mod/github.com/appbaseio/reactivesearch-api@v0.0.0-20211213071720-647e69aa1142/plugins/querytranslate/util.go:902 +0x1fc fp=0xc000fb8898 sp=0xc000fb8830 pc=0x7f1c3df5b57c
```

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc. N/A

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
