### PR TITLE
Expose lumberjack from logger outside package

### DIFF
--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -63,6 +63,11 @@ func (l *Logs) Name() string {
 	return logTag
 }
 
+// Get the Lumberjack logger
+func (l *Logs) Lumberjack() lumberjack.Logger {
+	return l.lumberjack
+}
+
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (l *Logs) InitFunc() error {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

The logger might be used in other places externally (cron scripts when run). Lumberjack is an important part of the logger and currently it is not exposed to other packages.

Added a patch to allow Lumberjack to be used externally from the logs plugin.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
