### PR TITLE
Fix issue with delta diff storage and working on it

### DIFF
--- a/model/difference/difference.go
+++ b/model/difference/difference.go
@@ -1,10 +1,12 @@
 package difference
 
+import "github.com/sergi/go-diff/diffmatchpatch"
+
 type Difference struct {
-	URI     string   `json:"uri"`
-	Headers string   `json:"headers"`
-	Body    string   `json:"body"`
-	Method  string   `json:"method"`
-	Stage   string   `json:"stage"`
-	Took    *float64 `json:"took,omitempty"`
+	URI     []diffmatchpatch.Diff `json:"uri"`
+	Headers []diffmatchpatch.Diff `json:"headers"`
+	Body    []diffmatchpatch.Diff `json:"body"`
+	Method  []diffmatchpatch.Diff `json:"method"`
+	Stage   string                `json:"stage"`
+	Took    *float64              `json:"took,omitempty"`
 }

--- a/model/difference/difference.go
+++ b/model/difference/difference.go
@@ -1,12 +1,10 @@
 package difference
 
-import "github.com/sergi/go-diff/diffmatchpatch"
-
 type Difference struct {
-	URI     []diffmatchpatch.Diff `json:"uri"`
-	Headers []diffmatchpatch.Diff `json:"headers"`
-	Body    []diffmatchpatch.Diff `json:"body"`
-	Method  []diffmatchpatch.Diff `json:"method"`
-	Stage   string                `json:"stage"`
-	Took    *float64              `json:"took,omitempty"`
+	URI     string   `json:"uri"`
+	Headers string   `json:"headers"`
+	Body    string   `json:"body"`
+	Method  string   `json:"method"`
+	Stage   string   `json:"stage"`
+	Took    *float64 `json:"took,omitempty"`
 }

--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -21,7 +21,6 @@ import (
 	"github.com/appbaseio/reactivesearch-api/model/difference"
 	"github.com/appbaseio/reactivesearch-api/model/op"
 	"github.com/appbaseio/reactivesearch-api/model/permission"
-	"github.com/appbaseio/reactivesearch-api/model/request"
 	"github.com/appbaseio/reactivesearch-api/model/requestchange"
 	"github.com/appbaseio/reactivesearch-api/model/trackplugin"
 	"github.com/appbaseio/reactivesearch-api/plugins/auth"
@@ -103,8 +102,10 @@ func saveRequestToCtx(h http.HandlerFunc) http.HandlerFunc {
 		// since it was emptied when we read it.
 		req.Body = ioutil.NopCloser(buf)
 
-		originalCtx := request.NewContext(req.Context(), body)
-		req = req.WithContext(originalCtx)
+		// No need to write original body, it will be written by search relevancy
+		// since the first modification happens there.
+		// originalCtx := request.NewContext(req.Context(), body)
+		// req = req.WithContext(originalCtx)
 		ctx := NewContext(req.Context(), body)
 		req = req.WithContext(ctx)
 

--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -21,6 +21,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/model/difference"
 	"github.com/appbaseio/reactivesearch-api/model/op"
 	"github.com/appbaseio/reactivesearch-api/model/permission"
+	"github.com/appbaseio/reactivesearch-api/model/request"
 	"github.com/appbaseio/reactivesearch-api/model/requestchange"
 	"github.com/appbaseio/reactivesearch-api/model/trackplugin"
 	"github.com/appbaseio/reactivesearch-api/plugins/auth"
@@ -104,8 +105,15 @@ func saveRequestToCtx(h http.HandlerFunc) http.HandlerFunc {
 
 		// No need to write original body, it will be written by search relevancy
 		// since the first modification happens there.
-		// originalCtx := request.NewContext(req.Context(), body)
-		// req = req.WithContext(originalCtx)
+		// NOTE: Set the original request if searchrelevancy is not available, i:e oss
+		originalReq, err := request.FromContext(req.Context())
+		log.Debug(logTag, "original req: ", originalReq)
+		if originalReq == nil {
+			log.Warnln(logTag, "Setting original request body since nil was found: ", originalReq)
+			originalCtx := request.NewContext(req.Context(), body)
+			req = req.WithContext(originalCtx)
+		}
+
 		ctx := NewContext(req.Context(), body)
 		req = req.WithContext(ctx)
 

--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -148,12 +148,23 @@ func queryTranslate(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 
+		shouldLogDiff := true
+
 		body, err := FromContext(req.Context())
 		if err != nil {
 			log.Errorln(logTag, ":", err)
 			telemetry.WriteBackErrorWithTelemetry(req, w, "error encountered while retrieving request from context", http.StatusInternalServerError)
 			return
 		}
+
+		// Marshal the body and save it as the one before modification
+		marshalledBody, err := json.Marshal(body)
+		if err != nil {
+			log.Warnln(logTag, "couldn't marshal body to run log diff on it, ", err)
+			shouldLogDiff = false
+		}
+
+		reqBodyBeforeModification := ioutil.NopCloser(strings.NewReader(string(marshalledBody)))
 
 		// validate request by permission
 		reqPermission, err := permission.FromContext(req.Context())
@@ -245,37 +256,39 @@ func queryTranslate(h http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		reqBeforeModification, err := util.DeepCloneRequest(req)
-		if err != nil {
-			log.Warnln(logTag, "error while cloning request for logging")
-		}
-
 		// Update the request body to the parsed query
 		req.Body = ioutil.NopCloser(strings.NewReader(msearchQuery))
 
-		reqAfterModification, err := util.DeepCloneRequest(req)
-		if err != nil {
-			log.Warningln(logTag, " error occurred while getting the request body after modification, ", err)
+		if shouldLogDiff {
+			reqBodyAfterModification := ioutil.NopCloser(strings.NewReader(string(msearchQuery)))
+
+			bodyDiffStr := util.CalculateBodyDiff(reqBodyBeforeModification, reqBodyAfterModification)
+
+			DiffCalculated := &difference.Difference{
+				Body:    bodyDiffStr,
+				Headers: util.CalculateHeaderDiff(req.Header, req.Header),
+				URI:     util.CalculateUriDiff(req, req),
+				Method:  util.CalculateMethodDiff(req, req),
+			}
+
+			timeTaken := float64(time.Since(start).Milliseconds())
+			DiffCalculated.Took = &timeTaken
+			DiffCalculated.Stage = "querytranslate"
+
+			// Save the diff to context
+			// Get all the diffs first, then append and update the context
+			currentDiffs, err := requestchange.FromContext(req.Context())
+			if err != nil {
+				log.Warnln(logTag, ": error while getting diff, creating new diff. Err: ", err)
+				madeDiffs := make([]difference.Difference, 0)
+				currentDiffs = &madeDiffs
+			}
+			*currentDiffs = append(*currentDiffs, *DiffCalculated)
+
+			// Save the value to the context
+			diffCtx := requestchange.NewContext(req.Context(), currentDiffs)
+			req = req.WithContext(diffCtx)
 		}
-
-		DiffCalculated := util.CalculateRequestDiff(reqBeforeModification, reqAfterModification)
-		timeTaken := float64(time.Since(start).Milliseconds())
-		DiffCalculated.Took = &timeTaken
-		DiffCalculated.Stage = "querytranslate"
-
-		// Save the diff to context
-		// Get all the diffs first, then append and update the context
-		currentDiffs, err := requestchange.FromContext(req.Context())
-		if err != nil {
-			log.Warnln(logTag, ": error while getting diff, creating new diff. Err: ", err)
-			madeDiffs := make([]difference.Difference, 0)
-			currentDiffs = &madeDiffs
-		}
-		*currentDiffs = append(*currentDiffs, *DiffCalculated)
-
-		// Save the value to the context
-		diffCtx := requestchange.NewContext(req.Context(), currentDiffs)
-		req = req.WithContext(diffCtx)
 
 		// Track plugin
 		ctxTrackPlugin := trackplugin.TrackPlugin(req.Context(), "qt")

--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -107,8 +107,8 @@ func saveRequestToCtx(h http.HandlerFunc) http.HandlerFunc {
 		// since the first modification happens there.
 		// NOTE: Set the original request if searchrelevancy is not available, i:e oss
 		originalReq, err := request.FromContext(req.Context())
-		log.Debug(logTag, "original req: ", originalReq)
-		if originalReq == nil {
+		log.Debug(logTag, "original req: ", *originalReq)
+		if *originalReq == nil {
 			log.Warnln(logTag, "Setting original request body since nil was found: ", originalReq)
 			originalCtx := request.NewContext(req.Context(), body)
 			req = req.WithContext(originalCtx)

--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -107,9 +107,8 @@ func saveRequestToCtx(h http.HandlerFunc) http.HandlerFunc {
 		// since the first modification happens there.
 		// NOTE: Set the original request if searchrelevancy is not available, i:e oss
 		originalReq, err := request.FromContext(req.Context())
-		log.Debug(logTag, "original req: ", *originalReq)
 		if *originalReq == nil {
-			log.Warnln(logTag, "Setting original request body since nil was found: ", originalReq)
+			log.Warnln(logTag, "Setting original request body since nil was found: ", *originalReq)
 			originalCtx := request.NewContext(req.Context(), body)
 			req = req.WithContext(originalCtx)
 		}

--- a/util/diff.go
+++ b/util/diff.go
@@ -91,6 +91,10 @@ func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadClo
 	bodyReadBuffer.ReadFrom(originalReqBody)
 	originalBodyStr := bodyReadBuffer.String()
 
+	// Reset the buffer else the data will be appended
+	// which will create weird side effects
+	bodyReadBuffer.Reset()
+
 	bodyReadBuffer.ReadFrom(modifiedReqBody)
 	modifiedBodyStr := bodyReadBuffer.String()
 

--- a/util/diff.go
+++ b/util/diff.go
@@ -85,7 +85,7 @@ func CalculateResponseDiff(originalRes *httptest.ResponseRecorder, modifiedRes *
 }
 
 // Calculate the diff in the body
-func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadCloser) string {
+func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadCloser) []diffmatchpatch.Diff {
 	bodyReadBuffer := new(bytes.Buffer)
 	bodyReadBuffer.ReadFrom(originalReqBody)
 	originalBodyStr := bodyReadBuffer.String()
@@ -95,42 +95,27 @@ func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadClo
 
 	dmp := diffmatchpatch.New()
 	bodyDiffs := dmp.DiffMain(originalBodyStr, modifiedBodyStr, false)
-	bodyDiffBytes, err := json.Marshal(bodyDiffs)
-	if err != nil {
-		log.Warnln("error while marshalling body diff")
-		return ""
-	}
 
-	return string(bodyDiffBytes)
+	return bodyDiffs
 }
 
 // Calculate the difference in the URI
-func CalculateUriDiff(originalReq *http.Request, modifiedReq *http.Request) string {
+func CalculateUriDiff(originalReq *http.Request, modifiedReq *http.Request) []diffmatchpatch.Diff {
 	dmp := diffmatchpatch.New()
 	URIDiffs := dmp.DiffMain(originalReq.URL.Path, modifiedReq.URL.Path, false)
-	URIDiffBytes, err := json.Marshal(URIDiffs)
-	if err != nil {
-		log.Warnln("error while marshalling URI diff")
-		return ""
-	}
 
-	return string(URIDiffBytes)
+	return URIDiffs
 }
 
 // Calculate method difference
-func CalculateMethodDiff(originalReq *http.Request, modifiedReq *http.Request) string {
+func CalculateMethodDiff(originalReq *http.Request, modifiedReq *http.Request) []diffmatchpatch.Diff {
 	dmp := diffmatchpatch.New()
 	methodDiff := dmp.DiffMain(originalReq.Method, modifiedReq.Method, false)
-	methodDiffBytes, err := json.Marshal(methodDiff)
-	if err != nil {
-		log.Warnln("error while marshalling method diff")
-		return ""
-	}
 
-	return string(methodDiffBytes)
+	return methodDiff
 }
 
-func CalculateHeaderDiff(originalReqHeader http.Header, modifiedReqHeader http.Header) string {
+func CalculateHeaderDiff(originalReqHeader http.Header, modifiedReqHeader http.Header) []diffmatchpatch.Diff {
 	originalHeaders, err := json.Marshal(originalReqHeader)
 	if err != nil {
 		log.Warnln(" could not marshal original request headers, ", err)
@@ -144,11 +129,6 @@ func CalculateHeaderDiff(originalReqHeader http.Header, modifiedReqHeader http.H
 
 	dmp := diffmatchpatch.New()
 	headerDiff := dmp.DiffMain(string(originalHeaders), string(modifiedHeaders), false)
-	headerDiffBytes, err := json.Marshal(headerDiff)
-	if err != nil {
-		log.Warnln("error while marshalling header diff")
-		return ""
-	}
 
-	return string(headerDiffBytes)
+	return headerDiff
 }

--- a/util/diff.go
+++ b/util/diff.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/appbaseio/reactivesearch-api/model/difference"
+	"github.com/gdexlab/go-render/render"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	log "github.com/sirupsen/logrus"
 )
@@ -92,6 +93,8 @@ func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadClo
 
 	bodyReadBuffer.ReadFrom(modifiedReqBody)
 	modifiedBodyStr := bodyReadBuffer.String()
+
+	log.Debug("Comparing: ", render.AsCode(originalBodyStr), " with: ", render.AsCode(modifiedBodyStr))
 
 	dmp := diffmatchpatch.New()
 	bodyDiffs := dmp.DiffMain(originalBodyStr, modifiedBodyStr, false)

--- a/util/diff.go
+++ b/util/diff.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 
 	"github.com/appbaseio/reactivesearch-api/model/difference"
-	"github.com/prometheus/common/log"
 	"github.com/sergi/go-diff/diffmatchpatch"
+	log "github.com/sirupsen/logrus"
 )
 
 // Deep clone the request body by also reading the body and keeping
@@ -95,23 +95,39 @@ func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadClo
 
 	dmp := diffmatchpatch.New()
 	bodyDiffs := dmp.DiffMain(originalBodyStr, modifiedBodyStr, false)
-	bodyDiffStr := dmp.DiffToDelta(bodyDiffs)
+	bodyDiffBytes, err := json.Marshal(bodyDiffs)
+	if err != nil {
+		log.Warnln("error while marshalling body diff")
+		return ""
+	}
 
-	return bodyDiffStr
+	return string(bodyDiffBytes)
 }
 
 // Calculate the difference in the URI
 func CalculateUriDiff(originalReq *http.Request, modifiedReq *http.Request) string {
 	dmp := diffmatchpatch.New()
 	URIDiffs := dmp.DiffMain(originalReq.URL.Path, modifiedReq.URL.Path, false)
-	return dmp.DiffToDelta(URIDiffs)
+	URIDiffBytes, err := json.Marshal(URIDiffs)
+	if err != nil {
+		log.Warnln("error while marshalling URI diff")
+		return ""
+	}
+
+	return string(URIDiffBytes)
 }
 
 // Calculate method difference
 func CalculateMethodDiff(originalReq *http.Request, modifiedReq *http.Request) string {
 	dmp := diffmatchpatch.New()
 	methodDiff := dmp.DiffMain(originalReq.Method, modifiedReq.Method, false)
-	return dmp.DiffToDelta(methodDiff)
+	methodDiffBytes, err := json.Marshal(methodDiff)
+	if err != nil {
+		log.Warnln("error while marshalling method diff")
+		return ""
+	}
+
+	return string(methodDiffBytes)
 }
 
 func CalculateHeaderDiff(originalReqHeader http.Header, modifiedReqHeader http.Header) string {
@@ -128,5 +144,11 @@ func CalculateHeaderDiff(originalReqHeader http.Header, modifiedReqHeader http.H
 
 	dmp := diffmatchpatch.New()
 	headerDiff := dmp.DiffMain(string(originalHeaders), string(modifiedHeaders), false)
-	return dmp.DiffToDelta(headerDiff)
+	headerDiffBytes, err := json.Marshal(headerDiff)
+	if err != nil {
+		log.Warnln("error while marshalling header diff")
+		return ""
+	}
+
+	return string(headerDiffBytes)
 }

--- a/util/diff.go
+++ b/util/diff.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 
 	"github.com/appbaseio/reactivesearch-api/model/difference"
-	"github.com/gdexlab/go-render/render"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	log "github.com/sirupsen/logrus"
 )
@@ -97,8 +96,6 @@ func CalculateBodyDiff(originalReqBody io.ReadCloser, modifiedReqBody io.ReadClo
 
 	bodyReadBuffer.ReadFrom(modifiedReqBody)
 	modifiedBodyStr := bodyReadBuffer.String()
-
-	log.Debug("Comparing: ", render.AsCode(originalBodyStr), " with: ", render.AsCode(modifiedBodyStr))
 
 	dmp := diffmatchpatch.New()
 	bodyDiffs := dmp.DiffMain(originalBodyStr, modifiedBodyStr, false)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

Earlier, the request/response changes were captured through diffs in the logs and were stored in `delta` to save storage to some extent. However, that approach comes with downsides, especially since if even one character is compromised, the whole delta breaks.

~~This PR fixes that by storing the diffs directly instead of the deltas. This will take a somewhat more storage as compared to the last approach but it is way robust than storing just the deltas.~~

This PR fixes those issues of storing the delta diff and make everything work seamlessly and be consistent.

### What else does this PR do?

It also adds support to log diffs from the `querytranslate` stage.

## What should your reviewer look out for in this PR?

~~The diffs can be tested using this script: https://codepen.io/deepjyoti30/pen/yLPBPwE?editors=0011~~

### Things to note about the above script

- ~~The `diffRaw` variable should be the diff that is logged (can be picked up directly from the log)~~
- The `text1` value should be string escaped. This can be done by copying the original request/header/URI from the log and running that string through `unescape()` in the console.
- The `doReverse` flag should be set to `true` when the patches are supposed to be removed from the `text1` variable as opposed to applying them. **This is useful for creating response body for each stage**

Older codepen to create diffs from delta will work: https://codepen.io/deepjyoti30/pen/yLPBPwE

> NOTE: To create response, the above code can be referred in order to **remove** patches instead of adding them in the reverse order.

<!--

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
