### PR TITLE
Add support for capturing `console.logs` from scripts and saving them in the logs

### DIFF
--- a/model/console/console.go
+++ b/model/console/console.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/appbaseio/reactivesearch-api/errors"
@@ -20,6 +21,11 @@ func NewContext(ctx context.Context, consoleStr *string) context.Context {
 	consoleStrValue := *consoleStr
 	consoleStrValue = string(consoleStrValue[:util.Min(len(consoleStrValue), 1000000)])
 	consoleLogs := strings.Split(consoleStrValue, "\n")
+
+	fmt.Println("passed: ", *consoleStr)
+	fmt.Println("limited: ", consoleStrValue)
+	fmt.Println("logs: ", consoleLogs)
+
 	return context.WithValue(ctx, CtxKey, &consoleLogs)
 }
 
@@ -30,6 +36,7 @@ func FromContext(ctx context.Context) (*[]string, error) {
 		return nil, errors.NewNotFoundInContextError("Console Logs")
 	}
 	changes, ok := ctxRequest.(*[]string)
+	fmt.Println("changes: ", changes)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
 	}

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -2,8 +2,10 @@ package console
 
 import (
 	"context"
+	"strings"
 
 	"github.com/appbaseio/reactivesearch-api/errors"
+	"github.com/appbaseio/reactivesearch-api/util"
 )
 
 type contextKey string
@@ -13,17 +15,21 @@ const CtxKey = contextKey("console-logs")
 
 // NewContext returns a context with the passed value stored against the
 // context key.
-func NewContext(ctx context.Context, request *string) context.Context {
-	return context.WithValue(ctx, CtxKey, request)
+func NewContext(ctx context.Context, consoleStr *string) context.Context {
+	// Parse the string and save it as an array
+	consoleStrValue := *consoleStr
+	consoleStrValue = string(consoleStrValue[:util.Min(len(consoleStrValue), 1000000)])
+	consoleLogs := strings.Split(consoleStrValue, "\n")
+	return context.WithValue(ctx, CtxKey, consoleLogs)
 }
 
 // FromContext retrieves the logs saved in the context.
-func FromContext(ctx context.Context) (*string, error) {
+func FromContext(ctx context.Context) (*[]string, error) {
 	ctxRequest := ctx.Value(CtxKey)
 	if ctxRequest == nil {
 		return nil, errors.NewNotFoundInContextError("Console Logs")
 	}
-	changes, ok := ctxRequest.(*string)
+	changes, ok := ctxRequest.(*[]string)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
 	}

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -2,9 +2,9 @@ package console
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/appbaseio/reactivesearch-api/errors"
+	"github.com/appbaseio/reactivesearch-api/util"
 )
 
 type contextKey string
@@ -25,9 +25,14 @@ func FromContext(ctx context.Context) (*[]string, error) {
 		return nil, errors.NewNotFoundInContextError("Console Logs")
 	}
 	consoleLogs, ok := ctxRequest.(*[]string)
-	fmt.Println("changes: ", consoleLogs)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
 	}
 	return consoleLogs, nil
+}
+
+// LimitConsoleString truncates the data if the string is more than
+// 10KB and returns a new string
+func LimitConsoleString(console string) string {
+	return string(console[:util.Min(len(console), 1000000)])
 }

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -13,17 +13,17 @@ const CtxKey = contextKey("console-logs")
 
 // NewContext returns a context with the passed value stored against the
 // context key.
-func NewContext(ctx context.Context, request *[]string) context.Context {
+func NewContext(ctx context.Context, request *string) context.Context {
 	return context.WithValue(ctx, CtxKey, request)
 }
 
-// FromContext retrieves the array of logs saved in the context.
-func FromContext(ctx context.Context) (*[]string, error) {
+// FromContext retrieves the logs saved in the context.
+func FromContext(ctx context.Context) (*string, error) {
 	ctxRequest := ctx.Value(CtxKey)
 	if ctxRequest == nil {
 		return nil, errors.NewNotFoundInContextError("Console Logs")
 	}
-	changes, ok := ctxRequest.(*[]string)
+	changes, ok := ctxRequest.(*string)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
 	}

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -3,10 +3,8 @@ package console
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/appbaseio/reactivesearch-api/errors"
-	"github.com/appbaseio/reactivesearch-api/util"
 )
 
 type contextKey string
@@ -16,17 +14,8 @@ const CtxKey = contextKey("console-logs")
 
 // NewContext returns a context with the passed value stored against the
 // context key.
-func NewContext(ctx context.Context, consoleStr *string) context.Context {
-	// Parse the string and save it as an array
-	consoleStrValue := *consoleStr
-	consoleStrValue = string(consoleStrValue[:util.Min(len(consoleStrValue), 1000000)])
-	consoleLogs := strings.Split(consoleStrValue, "\n")
-
-	fmt.Println("passed: ", *consoleStr)
-	fmt.Println("limited: ", consoleStrValue)
-	fmt.Println("logs: ", consoleLogs)
-
-	return context.WithValue(ctx, CtxKey, &consoleLogs)
+func NewContext(ctx context.Context, consoleStr *[]string) context.Context {
+	return context.WithValue(ctx, CtxKey, consoleStr)
 }
 
 // FromContext retrieves the logs saved in the context.
@@ -35,10 +24,10 @@ func FromContext(ctx context.Context) (*[]string, error) {
 	if ctxRequest == nil {
 		return nil, errors.NewNotFoundInContextError("Console Logs")
 	}
-	changes, ok := ctxRequest.(*[]string)
-	fmt.Println("changes: ", changes)
+	consoleLogs, ok := ctxRequest.(*[]string)
+	fmt.Println("changes: ", consoleLogs)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
 	}
-	return changes, nil
+	return consoleLogs, nil
 }

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -20,7 +20,7 @@ func NewContext(ctx context.Context, consoleStr *string) context.Context {
 	consoleStrValue := *consoleStr
 	consoleStrValue = string(consoleStrValue[:util.Min(len(consoleStrValue), 1000000)])
 	consoleLogs := strings.Split(consoleStrValue, "\n")
-	return context.WithValue(ctx, CtxKey, consoleLogs)
+	return context.WithValue(ctx, CtxKey, &consoleLogs)
 }
 
 // FromContext retrieves the logs saved in the context.

--- a/model/console/console.go
+++ b/model/console/console.go
@@ -1,0 +1,31 @@
+package console
+
+import (
+	"context"
+
+	"github.com/appbaseio/reactivesearch-api/errors"
+)
+
+type contextKey string
+
+// CtxKey is a key against which api request will get stored in the context.
+const CtxKey = contextKey("console-logs")
+
+// NewContext returns a context with the passed value stored against the
+// context key.
+func NewContext(ctx context.Context, request *[]string) context.Context {
+	return context.WithValue(ctx, CtxKey, request)
+}
+
+// FromContext retrieves the array of logs saved in the context.
+func FromContext(ctx context.Context) (*[]string, error) {
+	ctxRequest := ctx.Value(CtxKey)
+	if ctxRequest == nil {
+		return nil, errors.NewNotFoundInContextError("Console Logs")
+	}
+	changes, ok := ctxRequest.(*[]string)
+	if !ok {
+		return nil, errors.NewInvalidCastError("ctxRequest", "Console Logs")
+	}
+	return changes, nil
+}

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -129,8 +129,8 @@ func (l *Logs) recorder(h http.HandlerFunc) http.HandlerFunc {
 		r = r.WithContext(resDiffCtx)
 
 		// Init the console logs in the context
-		consoleLogs := new(string)
-		consoleLogsCtx := console.NewContext(r.Context(), consoleLogs)
+		consoleLogs := ""
+		consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
 		r = r.WithContext(consoleLogsCtx)
 
 		// Serve using response recorder
@@ -223,10 +223,7 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 	if err != nil {
 		log.Warnln(logTag, "couldn't extract console logs, ", err)
 	} else {
-		// Limit the size of the console logs to 10KB for one execution
-		consoleStrValue := *consoleStr
-		consoleStr := string(consoleStrValue[:util.Min(len(consoleStrValue), 1000000)])
-		rec.Response.Console = strings.Split(consoleStr, "\n")
+		rec.Response.Console = *consoleStr
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -219,7 +219,7 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 	rec.Response.Headers = response.Header
 
 	// Extract the console logs
-	consoleStr, err := console.FromContext(r.Context())
+	consoleStr, err := console.FromContext(ctx)
 	if err != nil {
 		log.Warnln(logTag, "couldn't extract console logs, ", err)
 	} else {

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -219,7 +219,7 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 	rec.Response.Headers = response.Header
 
 	// Extract the console logs
-	consoleStr, err := console.FromContext(ctx)
+	consoleStr, err := console.FromContext(r.Context())
 	if err != nil {
 		log.Warnln(logTag, "couldn't extract console logs, ", err)
 	} else {

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -129,7 +129,7 @@ func (l *Logs) recorder(h http.HandlerFunc) http.HandlerFunc {
 		r = r.WithContext(resDiffCtx)
 
 		// Init the console logs in the context
-		consoleLogs := ""
+		consoleLogs := make([]string, 0)
 		consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
 		r = r.WithContext(consoleLogsCtx)
 

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -128,10 +128,10 @@ func (l *Logs) recorder(h http.HandlerFunc) http.HandlerFunc {
 		resDiffCtx := responsechange.NewContext(r.Context(), &resDiff)
 		r = r.WithContext(resDiffCtx)
 
-		// Init the console logs in the context
-		consoleLogs := ""
-		consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
-		r = r.WithContext(consoleLogsCtx)
+		// // Init the console logs in the context
+		// consoleLogs := ""
+		// consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
+		// r = r.WithContext(consoleLogsCtx)
 
 		// Serve using response recorder
 		respRecorder := httptest.NewRecorder()

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -128,10 +128,10 @@ func (l *Logs) recorder(h http.HandlerFunc) http.HandlerFunc {
 		resDiffCtx := responsechange.NewContext(r.Context(), &resDiff)
 		r = r.WithContext(resDiffCtx)
 
-		// // Init the console logs in the context
-		// consoleLogs := ""
-		// consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
-		// r = r.WithContext(consoleLogsCtx)
+		// Init the console logs in the context
+		consoleLogs := ""
+		consoleLogsCtx := console.NewContext(r.Context(), &consoleLogs)
+		r = r.WithContext(consoleLogsCtx)
 
 		// Serve using response recorder
 		respRecorder := httptest.NewRecorder()

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -218,14 +218,6 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 	rec.Response.Status = http.StatusText(response.StatusCode)
 	rec.Response.Headers = response.Header
 
-	// Extract the console logs
-	consoleStr, err := console.FromContext(r.Context())
-	if err != nil {
-		log.Warnln(logTag, "couldn't extract console logs, ", err)
-	} else {
-		rec.Response.Console = *consoleStr
-	}
-
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Errorln(logTag, "can't read response body: ", err)
@@ -285,6 +277,14 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 		log.Warnln(logTag, "No response changes added with err: ", err)
 	} else {
 		rec.ResponseChanges = *responseChanges
+	}
+
+	// Extract the console logs
+	consoleStr, err := console.FromContext(ctx)
+	if err != nil {
+		log.Warnln(logTag, "couldn't extract console logs, ", err)
+	} else {
+		rec.Response.Console = *consoleStr
 	}
 
 	marshalledLog, err := json.Marshal(rec)

--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -86,6 +86,7 @@ type Response struct {
 	Headers map[string][]string
 	Took    *float64 `json:"took,omitempty"`
 	Body    string   `json:"body"`
+	Console []string `json:"console,omitempty"`
 }
 
 type record struct {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

We already have support for `fetch` but `console.log` is something that was not supported before. Since it is a nice addition in order to let the user debug scripts as well as capture logs according to their needs, this PR adds support for capturing `console.log` fields into an array (splitted on newline) and storing it in the logs.

## What should your reviewer look out for in this PR?

The maximum size for the log string is limited to 10KB

<!--

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
