### PR TITLE
Add support for storing `console_logs` at root level

### DIFF
--- a/plugins/logs/middleware.go
+++ b/plugins/logs/middleware.go
@@ -87,7 +87,6 @@ type Response struct {
 	Headers map[string][]string
 	Took    *float64 `json:"took,omitempty"`
 	Body    string   `json:"body"`
-	Console []string `json:"console,omitempty"`
 }
 
 type record struct {
@@ -98,6 +97,7 @@ type record struct {
 	RequestChanges  []difference.Difference `json:"requestChanges"`
 	ResponseChanges []difference.Difference `json:"responseChanges"`
 	Timestamp       time.Time               `json:"timestamp"`
+	Console         []string                `json:"console_logs"`
 }
 
 // Recorder records a log "record" for every request.
@@ -284,7 +284,7 @@ func (l *Logs) recordResponse(w *httptest.ResponseRecorder, r *http.Request, req
 	if err != nil {
 		log.Warnln(logTag, "couldn't extract console logs, ", err)
 	} else {
-		rec.Response.Console = *consoleStr
+		rec.Console = *consoleStr
 	}
 
 	marshalledLog, err := json.Marshal(rec)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The console logs were stored inside `response.console` till now. This PR attempts to change the log to `console_logs` and store it at the root level.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
