### PR TITLE
Hide auth details in URL from getting printed in the logs

### DIFF
--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -11,6 +12,7 @@ type WrapKitLoggerDebug struct {
 }
 
 func (logger WrapKitLoggerDebug) Printf(format string, vars ...interface{}) {
+	cleanSenstiveData(&vars)
 	log.Debugln("[ElasticSearch: Trace] => ", fmt.Sprintf(format, vars...))
 }
 
@@ -19,5 +21,31 @@ type WrapKitLoggerError struct {
 }
 
 func (logger WrapKitLoggerError) Printf(format string, vars ...interface{}) {
+	cleanSenstiveData(&vars)
 	log.Errorln("[ElasticSearch: Error] => ", fmt.Sprintf(format, vars...))
+}
+
+// cleanSenstiveData cleans credentials from the
+// variables, if any.
+func cleanSenstiveData(vars *[]interface{}) {
+	// Check if any var contains an URL, if it does, replace auth from the URL
+	for index, passedVar := range *vars {
+		// Cast the interface to a string
+		stringedVar, ok := passedVar.(string)
+		if !ok {
+			continue
+		}
+
+		// Check if URL
+		isURL, _ := regexp.MatchString(`^https?://(www.)?.+\..+$`, stringedVar)
+		if !isURL {
+			continue
+		}
+
+		// If it is an URL, clean it up
+		cleanerRe := regexp.MustCompile(`//.+:.+@`)
+		cleanedVar := cleanerRe.ReplaceAllString(stringedVar, "//***:***@")
+
+		(*vars)[index] = cleanedVar
+	}
 }

--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -43,8 +43,8 @@ func cleanSenstiveData(vars *[]interface{}) {
 		}
 
 		// If it is an URL, clean it up
-		cleanerRe := regexp.MustCompile(`//.+:.+@`)
-		cleanedVar := cleanerRe.ReplaceAllString(stringedVar, "//***:***@")
+		cleanerRe := regexp.MustCompile(`\/\/(?P<username>.+):.+@`)
+		cleanedVar := cleanerRe.ReplaceAllString(stringedVar, "//${username}:***@")
 
 		(*vars)[index] = cleanedVar
 	}


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

For ES connections, we are using `olivere/elastic`. This package expects us to provide them some logging utilities that are used by `elastic` directly to log error logs, warning logs etc.

These logs contain stuff like the ES connection URL. However, in a lot of cases these URL's can contain sensitive data like `username`, `password` in it.

This PR fixes that issue by intercepting the log vars, checking if any sensitive data is added and replacing them with `***` instead.

Example scenario:

`http://foo:bar@localhost:8000` will be changed to `http://foo:***@localhost:8000`

### [Loom explaining the change](https://www.loom.com/share/038a29fbe4d84f7c9fa693a71cbbdcce)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
