### PR TITLE
Print deprecation warnings as `debug` instead of `error`

### DIFF
--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -39,7 +39,7 @@ func DebugDeprecationWarns(formattedStr string) bool {
 	isDeprecated, _ := regexp.MatchString(`.*deprecation.*`, strings.ToLower(formattedStr))
 
 	if isDeprecated {
-		log.Debug("[ElasticSearch: Trace] => ", formattedStr)
+		log.Debugln("[ElasticSearch: Trace] => ", formattedStr)
 		return true
 	}
 

--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -19,5 +21,25 @@ type WrapKitLoggerError struct {
 }
 
 func (logger WrapKitLoggerError) Printf(format string, vars ...interface{}) {
-	log.Errorln("[ElasticSearch: Error] => ", fmt.Sprintf(format, vars...))
+	// If the log contains deprecation, print it as debug and return
+	formattedStr := fmt.Sprintf(format, vars...)
+	if DebugDeprecationWarns(formattedStr) {
+		return
+	}
+
+	log.Errorln("[ElasticSearch: Error] => ", formattedStr)
+}
+
+// DebugDeprecationWarns converts all the error logs containing
+// deprecation warnings to debug logs so that it doesn't invoke sentry
+func DebugDeprecationWarns(formattedStr string) bool {
+	// Check if any of the vars contain `deprecation` in it.
+	isDeprecated, _ := regexp.MatchString(`.*deprecation.*`, strings.ToLower(formattedStr))
+
+	if isDeprecated {
+		log.Debug("[ElasticSearch: Trace] => ", formattedStr)
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

There are some deprecation warnings posted by ES which are picked up by the elastic client we are using `olivere/elastic` and then printed.

The deprecation warnings are posted as `Error` logs and that invokes Sentry. However, these should be logged as `Debug` since it's not a breaking issue for now.

This PR fixes that by intercepting all `error` calls, checking if it's a deprecation call and then logging it as `debug` instead.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
