### PR TITLE
feat(reindex): add support for passing a script during re-indexing

### DIFF
--- a/model/reindex/util.go
+++ b/model/reindex/util.go
@@ -21,6 +21,7 @@ type ReindexConfig struct {
 	Exclude                 []string                `json:"exclude_fields"`
 	Types                   []string                `json:"types"`
 	Action                  []string                `json:"action,omitempty"`
+	Script                  string                  `json:"script"`
 }
 
 // AliasedIndices struct


### PR DESCRIPTION
#### What does this do / why do we need it?
This PR adds support for copying a field when re-indexing data from an index `A` to itself or to another index.

#### What should your reviewer look out for in this PR?

Main effect test:

Here, the script is used to copy `accommodates` field's value into `accommodates_new` field. It allows for scenarios such as duplicating a text field as a numeric type from the appbase.io dashboard.

```
curl 'http://localhost:8000/_reindex/airbeds-test-app' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Basic ${base64_credentials}'
  --data-raw '{"es_version":"7.10.2","script":"ctx._source.accommodates_new=ctx._source.accommodates","exclude_fields":["accommodates_int"]}' \
  --compressed
```

This change is side-effect free as a re-indexing request with an empty script value or a missing script key will not add the script parameter when re-indexing.

#### Which issue(s) does this PR fix?
This is a feature enhancement.

#### If this PR affects any API reference documentation, please share the updated endpoint references

- [x] I've updated the doc.

