### PR TITLE
Capture URI diff for the `querytranslate` stage

### DIFF
--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/appbaseio/reactivesearch-api/util"
 	"github.com/appbaseio/reactivesearch-api/util/iplookup"
+	"github.com/gorilla/mux"
 
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/middleware/classify"
@@ -156,6 +157,9 @@ func queryTranslate(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 
+		// Extract the index from the vars
+		vars := mux.Vars(req)
+
 		shouldLogDiff := true
 
 		body, err := FromContext(req.Context())
@@ -272,10 +276,13 @@ func queryTranslate(h http.HandlerFunc) http.HandlerFunc {
 
 			bodyDiffStr := util.CalculateBodyDiff(reqBodyBeforeModification, reqBodyAfterModification)
 
+			// Diff the URI manually for this stage
+			esURL := "/" + vars["index"] + "/_msearch"
+
 			DiffCalculated := &difference.Difference{
 				Body:    bodyDiffStr,
 				Headers: util.CalculateHeaderDiff(req.Header, req.Header),
-				URI:     util.CalculateUriDiff(req, req),
+				URI:     util.CalculateStringDiff(req.URL.Path, esURL),
 				Method:  util.CalculateMethodDiff(req, req),
 			}
 

--- a/util/diff.go
+++ b/util/diff.go
@@ -121,6 +121,14 @@ func CalculateUriDiff(originalReq *http.Request, modifiedReq *http.Request) stri
 	return dmp.DiffToDelta(URIDiffs)
 }
 
+// CalculateStringDiff calculates the delta diff between the passed
+// strings
+func CalculateStringDiff(text1 string, text2 string) string {
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(text1, text2, false)
+	return dmp.DiffToDelta(diffs)
+}
+
 // Calculate method difference
 func CalculateMethodDiff(originalReq *http.Request, modifiedReq *http.Request) string {
 	dmp := diffmatchpatch.New()


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The `querytranslate` stage makes an internal call to `_msearch` without making any changes to the request body's URI.

The current flow of capturing URI diff is to check the old request body and the new request body. Added a special case for the `querytranslate` stage where the diff is calculated between the current request URI and the `_msearch` endpoint.

### [Loom of changes](https://www.loom.com/share/7c40eda6269745fd943640f20541a6a7)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
