### PR TITLE
Add alternate logic to extract log by ID from ES

### DIFF
--- a/plugins/logs/handlers.go
+++ b/plugins/logs/handlers.go
@@ -192,8 +192,8 @@ func (l *Logs) getLogById() http.HandlerFunc {
 
 		raw, err := l.es.getRawLog(req.Context(), logID)
 		if err != nil {
-			log.Warnln(logTag, err.Error.Error())
-			telemetry.WriteBackErrorWithTelemetry(req, rw, err.Error.Error(), err.Code)
+			log.Warnln(logTag, err.Err.Error())
+			telemetry.WriteBackErrorWithTelemetry(req, rw, err.Err.Error(), err.Code)
 			return
 		}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The current implementation to get a log using the passed ID uses a term query. This PR changes that and uses the `GET` method from ES to get the document directly using the ID and for improved performance and better scalability.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
