### PR TITLE
fix(system template): add system index template for ES v8 and OS v1

### DIFF
--- a/util/es_template.go
+++ b/util/es_template.go
@@ -265,7 +265,7 @@ func SetSystemIndexTemplate() error {
 	version := GetVersion()
 	if version == 7 {
 		defaultSetting := fmt.Sprintf(`{
-			"index_patterns": [".*"],
+			"index_patterns": [".*", "metricbeat-*"],
 			"settings": %s,
 			"mappings": %s,
 			"order": 20

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -265,7 +265,7 @@ func SetSystemIndexTemplate() error {
 	version := GetVersion()
 	if version == 7 || version == 8 {
 		defaultSetting := fmt.Sprintf(`{
-			"index_patterns": [".*", "metricbeat-*"],
+			"index_patterns": [".*"],
 			"settings": %s,
 			"mappings": %s,
 			"order": 20

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -181,7 +181,7 @@ func SetDefaultIndexTemplate() error {
 	}`
 
 	version := GetVersion()
-	if version == 7 || version == 8 {
+	if version == 7 || version == 8 || version == 1 {
 		defaultSetting := fmt.Sprintf(`{
 			"index_patterns": ["*"],
 			"settings": %s,
@@ -263,7 +263,7 @@ func SetSystemIndexTemplate() error {
 	}`
 
 	version := GetVersion()
-	if version == 7 || version == 8 {
+	if version == 7 || version == 8 || version == 1 {
 		defaultSetting := fmt.Sprintf(`{
 			"index_patterns": [".*"],
 			"settings": %s,

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -263,7 +263,7 @@ func SetSystemIndexTemplate() error {
 	}`
 
 	version := GetVersion()
-	if version == 7 {
+	if version == 7 || version == 8 {
 		defaultSetting := fmt.Sprintf(`{
 			"index_patterns": [".*", "metricbeat-*"],
 			"settings": %s,


### PR DESCRIPTION
#### What does this do / why do we need it?

- System indexes template wasn't applied for ES v8. This PR fixes that.
- User indexes and system indexes template isn't applied for OS v1. This PR fixes that.
