### PR TITLE
fix(querytranslate): fixes terms query's ordering query

### DIFF
--- a/plugins/querytranslate/term.go
+++ b/plugins/querytranslate/term.go
@@ -211,7 +211,7 @@ func (query *Query) applyTermsAggsQuery(queryOptions *map[string]interface{}) er
 			}
 		} else {
 			termsQuery["order"] = map[string]interface{}{
-				"_term": &query.SortBy,
+				"_key": &query.SortBy,
 			}
 		}
 


### PR DESCRIPTION
#### What does this do / why do we need it?
The use of `_term` to order term aggregations is deprecated since ES 6.0 and is not supported in ES 8.0. It's usage throws the following error and affects term queries when the results are sorted in an ascending or descending order.

> Invalid aggregation order path [_term]. Cannot find aggregation named [_term]

Example showing query generation using this against an ES 8.0 cluster:

![](https://i.imgur.com/YJWTg9D.png)

#### What should your reviewer look out for in this PR?

This PR fixes the above to use `_key` instead. This usage will work for both ES 7.x, ES 8.x as well as OpenSearch 1.x upstream clusters.
