### PR TITLE
Add support for automatic router health checkup and kill

### DIFF
--- a/main.go
+++ b/main.go
@@ -522,6 +522,18 @@ func main() {
 	routerSwapper.Swap(router)
 	routerSwapper.SetRouterAttrs(address, port, https)
 
+	// Set the router health check
+	//
+	// NOTE: The folowing code should be run just before the
+	// server starts.
+	// In other words, the server should start withing 10 seconds
+	// of running the below code.
+	routerHealthCheck := plugins.RouterHealthCheckInstance()
+	routerHealthCheck.SetAttrs(port, address, https)
+	routerHealthCronJob := cron.New()
+	routerHealthCronJob.AddFunc("@every 10s", routerHealthCheck.Check)
+	routerHealthCronJob.Start()
+
 	// Finally start the server
 	routerSwapper.StartServer()
 }

--- a/main.go
+++ b/main.go
@@ -528,7 +528,7 @@ func main() {
 	// server starts.
 	// In other words, the server should start withing 10 seconds
 	// of running the below code.
-	log.Infoln(logTag, ": setting up router health check")
+	log.Info(logTag, ": setting up router health check")
 	routerHealthCheck := plugins.RouterHealthCheckInstance()
 	routerHealthCheck.SetAttrs(port, address, https)
 	routerHealthCronJob := cron.New()

--- a/main.go
+++ b/main.go
@@ -528,6 +528,7 @@ func main() {
 	// server starts.
 	// In other words, the server should start withing 10 seconds
 	// of running the below code.
+	log.Infoln(logTag, ": setting up router health check")
 	routerHealthCheck := plugins.RouterHealthCheckInstance()
 	routerHealthCheck.SetAttrs(port, address, https)
 	routerHealthCronJob := cron.New()

--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -3,6 +3,7 @@ package elasticsearch
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -126,5 +127,23 @@ func (es *elasticsearch) healthCheck() http.HandlerFunc {
 			return
 		}
 		util.WriteBackRaw(w, []byte{}, code)
+	}
+}
+
+// dryHealthCheck will return a dummy response everytime it's
+// called. This method can be used to check if the server is stuck
+// and whether or not a restart is necessary.
+func dryHealthCheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		response := map[string]interface{}{
+			"health": "ok",
+		}
+
+		// Marshal the response
+		//
+		// NOTE: No need to check error since response is manually created
+		// in the above lines
+		responseInBytes, _ := json.Marshal(response)
+		util.WriteBackRaw(w, responseInBytes, http.StatusOK)
 	}
 }

--- a/plugins/elasticsearch/routes.go
+++ b/plugins/elasticsearch/routes.go
@@ -116,7 +116,14 @@ func (es *elasticsearch) preprocess(mw []middleware.Middleware) error {
 		HandlerFunc: es.healthCheck(),
 		Description: "Retrieve the cluster health, both appbase.io and Elasticsearch",
 	}
-	routes = append(routes, indexRoute, healthCheckRoute)
+	dryHealthCheckRoute := plugins.Route{
+		Name:        "Dry Health Check",
+		Methods:     []string{http.MethodGet, http.MethodHead, http.MethodPost},
+		Path:        "/arc/_health",
+		HandlerFunc: dryHealthCheck(),
+		Description: "Return a dummy response to indicate routers are working",
+	}
+	routes = append(routes, indexRoute, healthCheckRoute, dryHealthCheckRoute)
 	return nil
 }
 

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -106,8 +106,9 @@ type RouterSwapper struct {
 }
 
 var (
-	singleton *RouterSwapper
-	once      sync.Once
+	singleton            *RouterSwapper
+	singletonHealthCheck *RouterHealthCheck
+	once                 sync.Once
 )
 
 // RouterSwapperInstance returns one instance and should be the
@@ -225,6 +226,13 @@ type RouterHealthCheck struct {
 	port    int
 	address string
 	isHttps bool
+}
+
+// RouterHealthCheckInstance returns one instance and should be the
+// only way health check is accessed
+func RouterHealthCheckInstance() *RouterHealthCheck {
+	once.Do(func() { singletonHealthCheck = &RouterHealthCheck{} })
+	return singletonHealthCheck
 }
 
 // Append will append the newly added detail to the HealthCheck

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -215,3 +215,34 @@ func (rs *RouterSwapper) RestartServer() {
 	// If shutdown was succesfull, start again.
 	rs.StartServer()
 }
+
+// RouterHealthCheck will handle checking the routers
+// health.
+type RouterHealthCheck struct {
+	// CheckDetails can contain maximum 3 elements.
+	CheckedDetails []bool
+}
+
+// Append will append the newly added detail to the HealthCheck
+// array making sure that it is of length 3.
+func (h *RouterHealthCheck) Append(status bool) {
+	// We do not need to check the length of the array.
+	// We can add an element at the end and store the
+	// last 3 elements.
+	h.CheckedDetails = append(h.CheckedDetails, status)
+
+	checkDetailsLength := len(h.CheckedDetails)
+
+	// If length is more than 3, keep the last 3
+	if checkDetailsLength > 3 {
+		h.CheckedDetails = h.CheckedDetails[checkDetailsLength-3:]
+	}
+}
+
+// Check will check the routers health by
+// hitting the dry health check endpoint.
+//
+// This function should be run with a cron job to be effective.
+func (h *RouterHealthCheck) Check() {
+
+}

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -273,8 +273,8 @@ func (h *RouterHealthCheck) Check() {
 	//
 	// We don't need the response, just need
 	// to check if there was an error and accordingly set the status.
-	_, err := http.Get(urlToHit)
-	if err != nil {
+	res, err := http.Get(urlToHit)
+	if err != nil || res.StatusCode != http.StatusOK {
 		status = false
 	}
 	log.Debug(logTag, ": health check status: ", status)
@@ -295,7 +295,7 @@ func (h *RouterHealthCheck) Check() {
 
 		if failCount >= 3 {
 			// Make the server exit
-			log.Fatalln("reactivesearch-api server has stopped accepting requests. Restarting server")
+			log.Fatalln("reactivesearch-api server has stopped accepting requests. Restarting server...!")
 		}
 	}
 }

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -214,7 +214,7 @@ func (rs *RouterSwapper) RestartServer() {
 	var newServer http.Server
 	rs.server = newServer
 
-	// If shutdown was succesfull, start again.
+	// If shutdown was successful, start again.
 	rs.StartServer()
 }
 

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -109,6 +109,7 @@ var (
 	singleton            *RouterSwapper
 	singletonHealthCheck *RouterHealthCheck
 	once                 sync.Once
+	healthCheckOnce      sync.Once
 )
 
 // RouterSwapperInstance returns one instance and should be the
@@ -222,16 +223,15 @@ func (rs *RouterSwapper) RestartServer() {
 type RouterHealthCheck struct {
 	// CheckDetails can contain maximum 3 elements.
 	CheckedDetails []bool
-
-	port    int
-	address string
-	isHttps bool
+	port           *int
+	address        *string
+	isHttps        *bool
 }
 
 // RouterHealthCheckInstance returns one instance and should be the
 // only way health check is accessed
 func RouterHealthCheckInstance() *RouterHealthCheck {
-	once.Do(func() { singletonHealthCheck = &RouterHealthCheck{} })
+	healthCheckOnce.Do(func() { singletonHealthCheck = &RouterHealthCheck{} })
 	return singletonHealthCheck
 }
 
@@ -260,11 +260,11 @@ func (h *RouterHealthCheck) Check() {
 
 	// Build the URL to hit
 	ssl := "http"
-	if h.isHttps {
+	if *h.isHttps {
 		ssl = "https"
 	}
 
-	urlToHit := fmt.Sprintf("%s://%s:%d%s", ssl, h.address, h.port, endpoint)
+	urlToHit := fmt.Sprintf("%s://%s:%d%s", ssl, *h.address, *h.port, endpoint)
 	log.Debug(logTag, ": Hitting ", urlToHit, " for health check")
 
 	status := true
@@ -303,7 +303,7 @@ func (h *RouterHealthCheck) Check() {
 // SetAttrs sets the router related attributes in the HealthCheck
 // struct.
 func (h *RouterHealthCheck) SetAttrs(port int, address string, isHttps bool) {
-	h.port = port
-	h.address = address
-	h.isHttps = isHttps
+	h.port = &port
+	h.address = &address
+	h.isHttps = &isHttps
 }

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -265,6 +265,7 @@ func (h *RouterHealthCheck) Check() {
 	}
 
 	urlToHit := fmt.Sprintf("%s://%s:%d%s", ssl, h.address, h.port, endpoint)
+	log.Debug(logTag, ": Hitting ", urlToHit, " for health check")
 
 	status := true
 
@@ -276,6 +277,7 @@ func (h *RouterHealthCheck) Check() {
 	if err != nil {
 		status = false
 	}
+	log.Debug(logTag, ": health check status: ", status)
 
 	h.Append(status)
 

--- a/plugins/route.go
+++ b/plugins/route.go
@@ -288,5 +288,12 @@ func (h *RouterHealthCheck) Check() {
 			log.Fatalln("reactivesearch-api server has stopped accepting requests. Restarting server")
 		}
 	}
+}
 
+// SetAttrs sets the router related attributes in the HealthCheck
+// struct.
+func (h *RouterHealthCheck) SetAttrs(port int, address string, isHttps bool) {
+	h.port = port
+	h.address = address
+	h.isHttps = isHttps
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

It is noticed a few times that the server stays alive but the router stops accepting requests, this might be a possible side effect of the router swapper feature.

This PR adds a cronjob right before the server starts serving. This job hits an endpoint `/arc/_health` and checks if the router is accepting requests. This cron job is run every 10 seconds.

If it fails for 3 times consecutively, then the server is stopped automatically using a `log.Fatalln()`.

## Endpoint added

A new endpoint `/arc/_health` was added. This endpoint always returns a `200 OK` and the following response:

```json
{
  "health": "ok"
}
```

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
