### PR TITLE
Add knn support for RS API

### DIFF
--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -72,7 +72,7 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 	}
 
 	// If no backend is passed for kNN, set it as `elasticsearch`
-	backendPassed := "elasticsearch"
+	backendPassed := ElasticSearch
 	if rsQuery.Settings != nil && rsQuery.Settings.Backend != nil {
 		backendPassed = *rsQuery.Settings.Backend
 	}
@@ -138,9 +138,9 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 				}
 
 				switch backendPassed {
-				case "elasticsearch":
+				case ElasticSearch:
 					finalQuery = applyElasticSearchKnn(finalQuery, query, minSize)
-				case "opensearch":
+				case OpenSearch:
 					finalQuery = applyOpenSearchKnn(finalQuery, query, minSize)
 				}
 			}
@@ -238,11 +238,11 @@ func applyOpenSearchKnn(queryMap map[string]interface{}, queryItem Query, size i
 }
 
 // GetDefaultScript returns the default script for the passed backend
-func GetDefaultScript(backend string) string {
+func GetDefaultScript(backend Backend) string {
 	switch backend {
-	case "elasticsearch":
+	case ElasticSearch:
 		return "cosineSimilarity(params.queryVector, params.dataField) + 1.0"
-	case "opensearch":
+	case OpenSearch:
 		return "cosinesimil"
 	}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -120,6 +120,11 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 					query.Candidates = &defaultCandidates
 				}
 
+				if query.Size == nil {
+					defaultSize := 10
+					query.Size = &defaultSize
+				}
+
 				switch backendPassed {
 				case "elasticsearch":
 					if query.Script == nil {
@@ -168,7 +173,11 @@ func shouldApplyKnn(query Query) bool {
 // applyElasticSearchKnn applies the knn query for elasticsearch
 // backend
 func applyElasticSearchKnn(queryMap map[string]interface{}, queryItem Query) map[string]interface{} {
-	// TODO: Set the size field
+	// Set the size field
+	minSize := *queryItem.Candidates
+	if minSize > *queryItem.Size {
+		minSize = *queryItem.Size
+	}
 
 	// Replace the query field
 	currentQuery := queryMap["query"]
@@ -187,6 +196,9 @@ func applyElasticSearchKnn(queryMap map[string]interface{}, queryItem Query) map
 
 	// Update the queryMap
 	queryMap["query"] = updatedQuery
+
+	// Set the size
+	queryMap["size"] = minSize
 
 	return queryMap
 }

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -121,6 +121,10 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 
 				switch *rsQuery.Settings.Backend {
 				case "elasticsearch":
+					if query.Script == nil {
+						defaultScript := GetDefaultScript(*rsQuery.Settings.Backend)
+						query.Script = &defaultScript
+					}
 					finalQuery = applyElasticSearchKnn(finalQuery)
 				}
 			}
@@ -165,6 +169,16 @@ func shouldApplyKnn(query Query) bool {
 func applyElasticSearchKnn(query map[string]interface{}) map[string]interface{} {
 
 	return query
+}
+
+// GetDefaultScript returns the default script for the passed backend
+func GetDefaultScript(backend string) string {
+	switch backend {
+	case "elasticsearch":
+		return "cosineSimilarity(params.queryVector, params.dataField) + 1.0"
+	case "opensearch":
+		return "cosinesimil"
+	}
 }
 
 // global function to transform the RS API query to _msearch equivalent query

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -173,12 +173,14 @@ func applyElasticSearchKnn(queryMap map[string]interface{}, queryItem Query) map
 	// Replace the query field
 	currentQuery := queryMap["query"]
 	updatedQuery := map[string]interface{}{
-		"script_score": currentQuery,
-		"script": map[string]interface{}{
-			"source": *queryItem.Script,
-			"params": map[string]interface{}{
-				"queryVector": *queryItem.QueryVector,
-				"dataField":   *queryItem.VectorDataField,
+		"script_score": map[string]interface{}{
+			"query": currentQuery,
+			"script": map[string]interface{}{
+				"source": *queryItem.Script,
+				"params": map[string]interface{}{
+					"queryVector": *queryItem.QueryVector,
+					"dataField":   *queryItem.VectorDataField,
+				},
 			},
 		},
 	}

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -105,6 +105,20 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 				}
 				finalQuery = mergeMaps(finalQuery, defaultQueryClone)
 			}
+
+			// If knn fields are passed, apply knn fields to the final query
+			if shouldApplyKnn(query) {
+				if rsQuery.Settings.Backend == nil {
+					defaultBackend := "elasticsearch"
+					rsQuery.Settings.Backend = &defaultBackend
+				}
+
+				switch *rsQuery.Settings.Backend {
+				case "elasticsearch":
+					finalQuery = applyElasticSearchKnn(finalQuery)
+				}
+			}
+
 			queryInBytes, err2 := json.Marshal(finalQuery)
 			if err2 != nil {
 				return mSearchQuery, err2
@@ -133,6 +147,18 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 	}
 
 	return mSearchQuery, nil
+}
+
+// shouldApplyKnn determines whether or not to apply KNN stage
+func shouldApplyKnn(query Query) bool {
+	return query.QueryVector != nil && query.VectorDataField != nil
+}
+
+// applyElasticSearchKnn applies the knn query for elasticsearch
+// backend
+func applyElasticSearchKnn(query map[string]interface{}) map[string]interface{} {
+
+	return query
 }
 
 // global function to transform the RS API query to _msearch equivalent query

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -130,13 +130,18 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 					minSize = *query.Size
 				}
 
+				// Set default script for the backend if none
+				// is passed
+				if query.Script == nil {
+					defaultScript := GetDefaultScript(backendPassed)
+					query.Script = &defaultScript
+				}
+
 				switch backendPassed {
 				case "elasticsearch":
-					if query.Script == nil {
-						defaultScript := GetDefaultScript(backendPassed)
-						query.Script = &defaultScript
-					}
 					finalQuery = applyElasticSearchKnn(finalQuery, query, minSize)
+				case "opensearch":
+					finalQuery = applyOpenSearchKnn(finalQuery, query, minSize)
 				}
 			}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -72,9 +72,9 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 	}
 
 	// If no backend is passed for kNN, set it as `elasticsearch`
-	if rsQuery.Settings.Backend == nil {
-		defaultBackend := "elasticsearch"
-		rsQuery.Settings.Backend = &defaultBackend
+	backendPassed := "elasticsearch"
+	if rsQuery.Settings != nil && rsQuery.Settings.Backend != nil {
+		backendPassed = *rsQuery.Settings.Backend
 	}
 
 	for _, query := range rsQuery.Query {
@@ -120,10 +120,10 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 					query.Candidates = &defaultCandidates
 				}
 
-				switch *rsQuery.Settings.Backend {
+				switch backendPassed {
 				case "elasticsearch":
 					if query.Script == nil {
-						defaultScript := GetDefaultScript(*rsQuery.Settings.Backend)
+						defaultScript := GetDefaultScript(backendPassed)
 						query.Script = &defaultScript
 					}
 					finalQuery = applyElasticSearchKnn(finalQuery, query)

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -71,6 +71,12 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 		}
 	}
 
+	// If no backend is passed for kNN, set it as `elasticsearch`
+	if rsQuery.Settings.Backend == nil {
+		defaultBackend := "elasticsearch"
+		rsQuery.Settings.Backend = &defaultBackend
+	}
+
 	for _, query := range rsQuery.Query {
 		if query.Execute == nil || *query.Execute {
 			translatedQuery, queryOptions, isGeneratedByValue, translateError := query.getQuery(rsQuery)
@@ -108,11 +114,6 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 
 			// If knn fields are passed, apply knn fields to the final query
 			if shouldApplyKnn(query) {
-				if rsQuery.Settings.Backend == nil {
-					defaultBackend := "elasticsearch"
-					rsQuery.Settings.Backend = &defaultBackend
-				}
-
 				// Apply default candidate number if nothing is passed
 				if query.Candidates == nil {
 					defaultCandidates := 10
@@ -179,6 +180,8 @@ func GetDefaultScript(backend string) string {
 	case "opensearch":
 		return "cosinesimil"
 	}
+
+	return ""
 }
 
 // global function to transform the RS API query to _msearch equivalent query

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -218,6 +218,7 @@ func applyOpenSearchKnn(queryMap map[string]interface{}, queryItem Query, size i
 			"query": currentQuery,
 			"script": map[string]interface{}{
 				"source": "knn_score",
+				"lang":   "knn",
 				"params": map[string]interface{}{
 					"query_value": *queryItem.QueryVector,
 					"field":       *queryItem.VectorDataField,

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -113,6 +113,12 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 					rsQuery.Settings.Backend = &defaultBackend
 				}
 
+				// Apply default candidate number if nothing is passed
+				if query.Candidates == nil {
+					defaultCandidates := 10
+					query.Candidates = &defaultCandidates
+				}
+
 				switch *rsQuery.Settings.Backend {
 				case "elasticsearch":
 					finalQuery = applyElasticSearchKnn(finalQuery)

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -271,6 +271,59 @@ func (o QueryFormat) MarshalJSON() ([]byte, error) {
 	return json.Marshal(queryFormat)
 }
 
+// Backend will be the backend to be used for the knn
+// response stage changes.
+type Backend int
+
+const (
+	ElasticSearch Backend = iota
+	OpenSearch
+)
+
+// String returns the string representation
+// of the Backend
+func (b Backend) String() string {
+	switch b {
+	case ElasticSearch:
+		return "elasticsearch"
+	case OpenSearch:
+		return "opensearch"
+	}
+	return ""
+}
+
+// UnmarshalJSON is the implementation of Unmarshaler interface to unmarshal the Backend
+func (b *Backend) UnmarshalJSON(bytes []byte) error {
+	var knnBackend string
+	err := json.Unmarshal(bytes, &knnBackend)
+	if err != nil {
+		return err
+	}
+
+	switch knnBackend {
+	case OpenSearch.String():
+		*b = OpenSearch
+	case ElasticSearch.String():
+		*b = ElasticSearch
+	default:
+		return fmt.Errorf("invalid kNN backend passed: %s", knnBackend)
+	}
+
+	return nil
+}
+
+// MarshalJSON is the implementation of the Marshaler interface to marshal the Backend
+func (b Backend) MarshalJSON() ([]byte, error) {
+	var knnBackend string
+	knnBackend = b.String()
+
+	if knnBackend == "" {
+		return nil, fmt.Errorf("invalid kNN backend passed: %s", knnBackend)
+	}
+
+	return json.Marshal(knnBackend)
+}
+
 // Query represents the query object
 type Query struct {
 	ID                          *string                    `json:"id,omitempty"` // component id
@@ -345,7 +398,7 @@ type Settings struct {
 	EnableSearchRelevancy *bool                   `json:"enableSearchRelevancy,omitempty"`
 	UseCache              *bool                   `json:"useCache,omitempty"`
 	QueryRule             *map[string]interface{} `json:"queryRule,omitempty"`
-	Backend               *string                 `json:"backend,omitempty"`
+	Backend               *Backend                `json:"backend,omitempty"`
 }
 
 // RSQuery represents the request body

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -325,6 +325,10 @@ type Query struct {
 	Stopwords                   *[]string                  `json:"customStopwords,omitempty"`
 	SearchLanguage              *string                    `json:"searchLanguage,omitempty"`
 	CalendarInterval            *string                    `json:"calendarinterval,omitempty"`
+	Script                      *string                    `json:"script,omitempty"`
+	QueryVector                 *[]float64                 `json:"queryVector,omitempty"`
+	VectorDataField             *string                    `json:"vectorDataField,omitempty"`
+	Candidates                  *int                       `json:"candidates,omitempty"`
 }
 
 type DataField struct {

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -345,6 +345,7 @@ type Settings struct {
 	EnableSearchRelevancy *bool                   `json:"enableSearchRelevancy,omitempty"`
 	UseCache              *bool                   `json:"useCache,omitempty"`
 	QueryRule             *map[string]interface{} `json:"queryRule,omitempty"`
+	Backend               *string                 `json:"backend,omitempty"`
 }
 
 // RSQuery represents the request body


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for the user to use the `script_score` functionality of ES/OS to reorder the results based on a kNN script.

Few new fields are added:

- `query.queryVector`: The vector data to use in the kNN script
- `query.vectorDataField`: The field to run `kNN` on. Should of type `dense_vector` for ES.
- `query.script`: The script to use for reordering.
- `query.candidates`: Number of candidates to run the reordering script on.

Besides this, a `backend` field is also provided through `settings.backend` which is by default set to `elasticsearch`.

### When is it invoked?

When the user passes both `vectorDataField` and `queryVector` in the query, this script is invoked.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
