### PR TITLE
fix(http-client): use util.HTTPClient() over http.DefaultClient

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -413,6 +414,14 @@ func main() {
 	util.NewClient()
 	util.SetDefaultIndexTemplate()
 	util.SetSystemIndexTemplate()
+
+	/*
+	   Safety net for 'too many open files' issue on legacy code.
+	   Set a sane timeout duration for the http.DefaultClient, to ensure idle connections are terminated.
+	   Reference: https://stackoverflow.com/questions/37454236/net-http-server-too-many-open-files-error
+	*/
+	http.DefaultClient.Timeout = time.Minute * 2
+
 	// map of specific plugins
 	sequencedPlugins := []string{"analytics.so", "searchrelevancy.so", "rules.so", "cache.so", "suggestions.so", "storedquery.so", "analyticsrequest.so", "applycache.so"}
 	sequencedPluginsByPath := make(map[string]string)

--- a/plugins/telemetry/dao.go
+++ b/plugins/telemetry/dao.go
@@ -21,7 +21,7 @@ func postTelemetryToACCAPI(record interface{}) error {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := util.HTTPClient().Do(req)
 	if err != nil {
 		log.Errorln("error while recording telemetry:", err)
 		return err

--- a/plugins/users/util.go
+++ b/plugins/users/util.go
@@ -24,7 +24,7 @@ func subscribeToDowntimeAlert(email string) error {
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("cache-control", "no-cache")
 
-		res, err := http.DefaultClient.Do(req)
+		res, err := util.HTTPClient().Do(req)
 		if err != nil {
 			log.Errorln("error while subscribing to downtime alerts:", err)
 			return err
@@ -49,7 +49,7 @@ func unsubscribeToDowntimeAlert(email string) error {
 		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("cache-control", "no-cache")
 
-		res, err := http.DefaultClient.Do(req)
+		res, err := util.HTTPClient().Do(req)
 		if err != nil {
 			log.Errorln("error while un-subscribing to downtime alerts:", err)
 			return err

--- a/util/billing.go
+++ b/util/billing.go
@@ -209,7 +209,7 @@ func getArcInstance(arcID string) (ArcInstance, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	// If ACCAPI is down then set the plan
 	if (res != nil && res.StatusCode >= 500) || err != nil {
 		plan := GetTier()
@@ -272,7 +272,7 @@ func getArcClusterInstance(clusterID string) (ArcInstance, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	// If ACCAPI is down then set the plan
 	if (res != nil && res.StatusCode >= 500) || err != nil {
 		plan := GetTier()
@@ -358,7 +358,7 @@ func getClusterPlan(clusterID string) (ClusterPlan, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	// If ACCAPI is down then set the plan
 	if (res != nil && res.StatusCode >= 500) || err != nil {
 		plan := GetTier()
@@ -440,7 +440,7 @@ func reportUsageRequest(arcUsage ArcUsage) (ArcUsageResponse, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	// If ACCAPI is down then set the plan
 	if (res != nil && res.StatusCode >= 500) || err != nil {
 		plan := GetTier()
@@ -481,7 +481,7 @@ func reportClusterUsageRequest(arcUsage ArcUsage) (ArcUsageResponse, error) {
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	// If ACCAPI is down then set the plan
 	if (res != nil && res.StatusCode >= 500) || err != nil {
 		plan := GetTier()

--- a/util/test_utils.go
+++ b/util/test_utils.go
@@ -87,7 +87,7 @@ func MakeHttpRequest(method string, url string, requestBody interface{}) (interf
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	if err != nil {
 		log.Errorln("error while sending request:", err)
 		return nil, err, nil

--- a/util/util.go
+++ b/util/util.go
@@ -282,7 +282,7 @@ func MakeRequest(url, method string, reqBody []byte) ([]byte, *http.Response, er
 		log.Errorln("Error while creating request object: ", err)
 		return nil, nil, err
 	}
-	response, err := http.DefaultClient.Do(request)
+	response, err := HTTPClient().Do(request)
 	if err != nil {
 		log.Errorln("Error while making request: ", err)
 		return nil, nil, err
@@ -381,7 +381,7 @@ func ProxyACCAPI(proxyConfig ProxyConfig) (*http.Response, error) {
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("cache-control", "no-cache")
-	res, err := http.DefaultClient.Do(req)
+	res, err := HTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What does this do / why do we need it?

This PR fixes the use of http.DefaultClient and replaces it with util.HTTPClient(). There are some HTTP timeout related errors that the server runs into when proxying long running API requests as explained over here: https://stackoverflow.com/questions/37454236/net-http-server-too-many-open-files-error

Additional fix:
- also sets a safety net for timeout in case of a future accidental use of http.DefaultClient

#### What should your reviewer look out for in this PR?

We already use `util.HTTPClient()` in several places. This PR makes this use consistent. I don't anticipate a side-effect due to the use of it.

#### Which issue(s) does this PR fix?

In response to the following server error:
> http: Accept error: accept tcp [::]:8000: accept4: too many open files; retrying in 1s

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A
<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
