### PR TITLE
Add support to parse logs with a `verbose` flag for get log by ID

### DIFF
--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -146,8 +146,8 @@ func (es *elasticsearch) getRawLogs(ctx context.Context, logsFilter logsFilter) 
 	}
 }
 
-func (es *elasticsearch) getRawLog(ctx context.Context, ID string) ([]byte, *LogError) {
-	return es.getRawLogES7(ctx, ID)
+func (es *elasticsearch) getRawLog(ctx context.Context, ID string, parseDiffs bool) ([]byte, *LogError) {
+	return es.getRawLogES7(ctx, ID, parseDiffs)
 }
 
 func (es *elasticsearch) rolloverIndexJob(alias string) {

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -295,7 +295,14 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		return updatedLogInBytes, err
 	}
 
-	return updatedLogInBytes, nil
+	finalLogInBytes, err := json.Marshal(logMap)
+	if err != nil {
+		errMsg := fmt.Sprint("error while marshaling the final log, ", err)
+		log.Warnln(logTag, ": ", errMsg)
+		return updatedLogInBytes, errors.New(errMsg)
+	}
+
+	return finalLogInBytes, nil
 }
 
 // parseStringToMap Parses JSON for the passed map

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -205,6 +205,17 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 
 			logRecord.RequestChanges[changeIndex].Headers = headerText2
 		}
+
+		if change.URI != "" {
+			URIText1 := request.URI
+			URIText2, err := util.ApplyDelta(URIText1, change.URI)
+			if err != nil {
+				errMsg := fmt.Sprintf("error while apply delta for URI in stage %d, %s", changeIndex, err)
+				return logPassed, errors.New(errMsg)
+			}
+
+			logRecord.RequestChanges[changeIndex].URI = URIText2
+		}
 	}
 
 	updatedLogInBytes, err := json.Marshal(logRecord)

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -184,7 +184,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Body != "" {
 			bodyText2, err := util.ApplyDelta(bodyText1, change.Body)
 			if err != nil {
-				errMsg := fmt.Sprint("error while applying body delta for stage number: ", err)
+				errMsg := fmt.Sprintf("error while applying body delta for stage number %d, %s ", changeIndex, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -194,7 +194,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Headers != "" {
 			headerText1, err := json.Marshal(request.Headers)
 			if err != nil {
-				errMsg := fmt.Sprint("error while marshalling headers for stage number: ", err)
+				errMsg := fmt.Sprintf("error while marshalling headers for stage number %d, %s ", changeIndex, err)
 				return logPassed, errors.New(errMsg)
 			}
 			headerText2, err := util.ApplyDelta(string(headerText1), change.Headers)

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -11,7 +11,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/model/category"
 	"github.com/appbaseio/reactivesearch-api/util"
 	es7 "github.com/olivere/elastic/v7"
-	"github.com/prometheus/common/log"
+	log "github.com/sirupsen/logrus"
 )
 
 func (es *elasticsearch) getRawLogsES7(ctx context.Context, logsFilter logsFilter) ([]byte, error) {
@@ -285,16 +285,6 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		return updatedLogInBytes, errors.New(errMsg)
 	}
 
-	logMap["requestChanges"], err = parseStringToMap(logMap["requestChanges"])
-	if err != nil {
-		return updatedLogInBytes, err
-	}
-
-	logMap["responseChanges"], err = parseStringToMap(logMap["responseChanges"])
-	if err != nil {
-		return updatedLogInBytes, err
-	}
-
 	finalLogInBytes, err := json.Marshal(logMap)
 	if err != nil {
 		errMsg := fmt.Sprint("error while marshaling the final log, ", err)
@@ -320,12 +310,13 @@ func parseStringToMap(changes interface{}) (interface{}, error) {
 			return requestChanges, errors.New(errMsg)
 		}
 
-		if changeAsMap["body"] == "" {
+		// Convert the string to map
+		bodyAsString := changeAsMap["body"].(string)
+
+		if bodyAsString == "" {
 			continue
 		}
 
-		// Convert the string to map
-		bodyAsString := changeAsMap["body"].(string)
 		bodyAsMap := make(map[string]interface{})
 		err := json.Unmarshal([]byte(bodyAsString), &bodyAsMap)
 		if err != nil {

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -210,11 +210,22 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 			URIText1 := request.URI
 			URIText2, err := util.ApplyDelta(URIText1, change.URI)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while apply delta for URI in stage %d, %s", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex, err)
 				return logPassed, errors.New(errMsg)
 			}
 
 			logRecord.RequestChanges[changeIndex].URI = URIText2
+		}
+
+		if change.Method != "" {
+			MethodText1 := request.Method
+			MethodText2, err := util.ApplyDelta(MethodText1, change.Method)
+			if err != nil {
+				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex, err)
+				return logPassed, errors.New(errMsg)
+			}
+
+			logRecord.RequestChanges[changeIndex].Method = MethodText2
 		}
 	}
 

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -242,7 +242,12 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		return logPassed, errors.New(errMsg)
 	}
 
-	for changeIndex, change := range logRecord.ResponseChanges {
+	// Iterate response changes in reverse order since we get the final response
+	// in the root log.
+	//
+	// We also need to keep updating the body and header
+	for changeIndex := len(logRecord.ResponseChanges) - 1; changeIndex >= 0; changeIndex-- {
+		change := logRecord.ResponseChanges[changeIndex]
 		if change.Body != "" {
 			bodyText2, err := util.ApplyDelta(responseBodyText1, change.Body)
 			if err != nil {

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -191,7 +191,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Body != "" {
 			bodyText2, err := util.ApplyDelta(bodyText1, change.Body)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while applying body delta for stage number %d, %s ", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying body delta for stage number %d, %s ", changeIndex+1, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -213,7 +213,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.URI != "" {
 			URIText2, err := util.ApplyDelta(URIText1, change.URI)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex+1, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -224,7 +224,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Method != "" {
 			MethodText2, err := util.ApplyDelta(MethodText1, change.Method)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying delta for URI in stage %d, %s", changeIndex+1, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -251,7 +251,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Body != "" {
 			bodyText2, err := util.ApplyDelta(responseBodyText1, change.Body)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while applying body delta to response for stage number %d,  %s", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying body delta to response for stage number %d,  %s", changeIndex+1, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -262,7 +262,7 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		if change.Headers != "" {
 			headerText2, err := util.ApplyDelta(string(responseHeaderText1), change.Headers)
 			if err != nil {
-				errMsg := fmt.Sprintf("error while applying response header delta for stage number %d, %s ", changeIndex, err)
+				errMsg := fmt.Sprintf("error while applying response header delta for stage number %d, %s ", changeIndex+1, err)
 				return logPassed, errors.New(errMsg)
 			}
 
@@ -335,7 +335,7 @@ func parseStringToMap(changes interface{}) (interface{}, error) {
 			if err != nil {
 				// It's possible that the body is nd-json in which case, we will
 				// not raise an error and return the body as string.
-				errMsg := fmt.Sprint("error while parsing body to map from string, ", err)
+				errMsg := fmt.Sprintf("error while parsing body to map from string for stage %d with err: %s", changeIndex+1, err)
 				log.Warnln(logTag, ": ", errMsg, " Returning as string.")
 			} else {
 				changeAsMap["body"] = bodyAsMap

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -107,7 +107,7 @@ func (es *elasticsearch) getRawLogsES7(ctx context.Context, logsFilter logsFilte
 
 // getRawLogES7 will get the raw log for the log with passed ID.
 // If we don't find a match, we will raise a 404 error.
-func (es *elasticsearch) getRawLogES7(ctx context.Context, ID string) ([]byte, *LogError) {
+func (es *elasticsearch) getRawLogES7(ctx context.Context, ID string, parseDiffs bool) ([]byte, *LogError) {
 	response, err := util.GetClient7().Get().Index(es.indexName).Id(ID).Do(ctx)
 
 	if err != nil {

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -285,6 +285,19 @@ func parseStageDiffs(logPassed []byte) ([]byte, error) {
 		return updatedLogInBytes, errors.New(errMsg)
 	}
 
+	// Parse the strings to JSON
+	logMap["requestChanges"], err = parseStringToMap(logMap["requestChanges"])
+	if err != nil {
+		errMsg := fmt.Sprint("error while parsing request changes, ", err)
+		return nil, errors.New(errMsg)
+	}
+
+	logMap["responseChanges"], err = parseStringToMap(logMap["responseChanges"])
+	if err != nil {
+		errMsg := fmt.Sprint("error while parsing response changes, ", err)
+		return nil, errors.New(errMsg)
+	}
+
 	finalLogInBytes, err := json.Marshal(logMap)
 	if err != nil {
 		errMsg := fmt.Sprint("error while marshaling the final log, ", err)

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -342,6 +342,25 @@ func parseStringToMap(changes interface{}) (interface{}, error) {
 			}
 		}
 
+		// Convert the headers to map
+		headersAsString := changeAsMap["headers"].(string)
+
+		// NOTE: Since there are no following actions, we can skip the iteration
+		// if headers is empty,
+		if headersAsString == "" {
+			continue
+		}
+
+		headersAsMap := make(map[string]interface{})
+		err := json.Unmarshal([]byte(headersAsString), &headersAsMap)
+		if err != nil {
+			// If headers failed, throw error since this should always be a map.
+			errMsg := fmt.Sprintf("error while parsing headers for stage %d with err: %s", changeIndex+1, err)
+			return nil, errors.New(errMsg)
+		}
+
+		changeAsMap["headers"] = headersAsMap
+
 		requestChanges[changeIndex] = changeAsMap
 	}
 

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -326,19 +326,20 @@ func parseStringToMap(changes interface{}) (interface{}, error) {
 		// Convert the string to map
 		bodyAsString := changeAsMap["body"].(string)
 
-		if bodyAsString == "" {
-			continue
-		}
-
-		bodyAsMap := make(map[string]interface{})
-		err := json.Unmarshal([]byte(bodyAsString), &bodyAsMap)
-		if err != nil {
-			// It's possible that the body is nd-json in which case, we will
-			// not raise an error and return the body as string.
-			errMsg := fmt.Sprint("error while parsing body to map from string, ", err)
-			log.Warnln(logTag, ": ", errMsg, " Returning as string.")
-		} else {
-			changeAsMap["body"] = bodyAsMap
+		// NOTE: Cannot do the opposite check and make the iteration
+		// skipped using continue because we will be parsing
+		// headers as well.
+		if bodyAsString != "" {
+			bodyAsMap := make(map[string]interface{})
+			err := json.Unmarshal([]byte(bodyAsString), &bodyAsMap)
+			if err != nil {
+				// It's possible that the body is nd-json in which case, we will
+				// not raise an error and return the body as string.
+				errMsg := fmt.Sprint("error while parsing body to map from string, ", err)
+				log.Warnln(logTag, ": ", errMsg, " Returning as string.")
+			} else {
+				changeAsMap["body"] = bodyAsMap
+			}
 		}
 
 		requestChanges[changeIndex] = changeAsMap

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -333,11 +333,14 @@ func parseStringToMap(changes interface{}) (interface{}, error) {
 		bodyAsMap := make(map[string]interface{})
 		err := json.Unmarshal([]byte(bodyAsString), &bodyAsMap)
 		if err != nil {
+			// It's possible that the body is nd-json in which case, we will
+			// not raise an error and return the body as string.
 			errMsg := fmt.Sprint("error while parsing body to map from string, ", err)
-			return requestChanges, errors.New(errMsg)
+			log.Warnln(logTag, ": ", errMsg, " Returning as string.")
+		} else {
+			changeAsMap["body"] = bodyAsMap
 		}
 
-		changeAsMap["body"] = bodyAsMap
 		requestChanges[changeIndex] = changeAsMap
 	}
 

--- a/plugins/logs/handlers.go
+++ b/plugins/logs/handlers.go
@@ -191,7 +191,7 @@ func (l *Logs) getLogById() http.HandlerFunc {
 		logID := vars["id"]
 
 		// ParseDiff flag
-		parseDiffs := req.URL.Query().Get("parseDiffs")
+		parseDiffs := req.URL.Query().Get("verbose")
 		parseDiffBool := true
 		if parseDiffs == "false" {
 			parseDiffBool = false

--- a/plugins/logs/handlers.go
+++ b/plugins/logs/handlers.go
@@ -190,7 +190,14 @@ func (l *Logs) getLogById() http.HandlerFunc {
 		vars := mux.Vars(req)
 		logID := vars["id"]
 
-		raw, err := l.es.getRawLog(req.Context(), logID)
+		// ParseDiff flag
+		parseDiffs := req.URL.Query().Get("parseDiffs")
+		parseDiffBool := true
+		if parseDiffs == "false" {
+			parseDiffBool = false
+		}
+
+		raw, err := l.es.getRawLog(req.Context(), logID, parseDiffBool)
 		if err != nil {
 			log.Warnln(logTag, err.Err.Error())
 			telemetry.WriteBackErrorWithTelemetry(req, rw, err.Err.Error(), err.Code)

--- a/plugins/logs/service.go
+++ b/plugins/logs/service.go
@@ -4,7 +4,7 @@ import "context"
 
 type logsService interface {
 	getRawLogs(ctx context.Context, logsFilter logsFilter) ([]byte, error)
-	getRawLog(ctx context.Context, ID string) ([]byte, *LogError)
+	getRawLog(ctx context.Context, ID string, parseDiffs bool) ([]byte, *LogError)
 	indexRecord(ctx context.Context, r record)
 	rolloverIndexJob(alias string)
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support to parse logs with a `verbose` flag for get log by ID. The flag is set to `true` by default and can be disabled by passing `verbose=false`.

> The fields are not JSON parsed because there can be ndjson which fails the parsing altogether.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
