### PR TITLE
fix(http-client): set max connections per host setting

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -231,6 +231,8 @@ func HTTPClient() *http.Client {
 			DialContext: (&net.Dialer{
 				Timeout: 10 * time.Second,
 			}).DialContext,
+			MaxIdleConnsPerHost: 100,
+			MaxConnsPerHost:     100,
 			TLSHandshakeTimeout: 10 * time.Second,
 			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 		}


### PR DESCRIPTION
#### What does this do / why do we need it?

This PR updates the default values of `MaxConnsPerHost` and `MaxIdleConnsPerHost` to 100 from 2. While HTTP client allows up to 100 connections, it caps to a max of [2 connections per host](https://github.com/golang/go/blob/master/src/net/http/transport.go#L58).

In scenarios such as sending bulk indexing requests to an upstream Elasticsearch cluster, this becomes problematic when the gateway (RS API server) has more than 2 active HTTP connections open, which is usually the case.

#### What should your reviewer look out for in this PR?

This PR shouldn't create a side-effect as it allows utilizing up to 100 active connections for a single upstream host, which is how RS API server will likely be used.

Test scenario used: index in bulk using the ABC cli. Prior to this PR, the RS API server crashes with a 502 bad gateway error code. Post this PR, it doesn't.

**Note:** For future, it may be worth investigating the 100 threshold as a higher threshold than 100 can allow for improved performance at the tradeoff of system resources. 

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A
<!--

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
