### PR TITLE
fix(elasticsearch): allow pinging with any type of credentials

### DIFF
--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -130,6 +130,23 @@ func (es *elasticsearch) healthCheck() http.HandlerFunc {
 	}
 }
 
+func (es *elasticsearch) pingES() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		result, code, err := util.GetClient7().Ping(util.GetESURL()).Do(context.Background())
+		if err != nil {
+			log.Errorln(logTag, ": error fetching ES cluster health", err)
+			telemetry.WriteBackErrorWithTelemetry(r, w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		responseInBytes, err := json.Marshal(result)
+		if err != nil {
+			log.Errorln(logTag, ": error while marshalling the ping result", err)
+			util.WriteBackError(w, err.Error(), http.StatusInternalServerError)
+		}
+		util.WriteBackRaw(w, responseInBytes, code)
+	}
+}
+
 // dryHealthCheck will return a dummy response everytime it's
 // called. This method can be used to check if the server is stuck
 // and whether or not a restart is necessary.

--- a/plugins/elasticsearch/routes.go
+++ b/plugins/elasticsearch/routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/model/category"
 	"github.com/appbaseio/reactivesearch-api/model/op"
 	"github.com/appbaseio/reactivesearch-api/plugins"
+	"github.com/appbaseio/reactivesearch-api/plugins/auth"
 	"github.com/appbaseio/reactivesearch-api/util"
 	"github.com/gobuffalo/packr"
 )
@@ -106,7 +107,7 @@ func (es *elasticsearch) preprocess(mw []middleware.Middleware) error {
 		Name:        "ping",
 		Methods:     []string{http.MethodGet, http.MethodHead},
 		Path:        "/",
-		HandlerFunc: es.pingES(),
+		HandlerFunc: (&chain{}).Adapt(es.pingES(), classifyCategory, classifyOp, auth.BasicAuth()),
 		Description: "You know, for search",
 	}
 	healthCheckRoute := plugins.Route{

--- a/plugins/elasticsearch/routes.go
+++ b/plugins/elasticsearch/routes.go
@@ -106,7 +106,7 @@ func (es *elasticsearch) preprocess(mw []middleware.Middleware) error {
 		Name:        "ping",
 		Methods:     []string{http.MethodGet, http.MethodHead},
 		Path:        "/",
-		HandlerFunc: middlewareFunction(mw, es.handler()),
+		HandlerFunc: es.pingES(),
 		Description: "You know, for search",
 	}
 	healthCheckRoute := plugins.Route{


### PR DESCRIPTION
#### What does this do / why do we need it?

`/` is used to identify the Elasticsearch version being used and used by several ES community plugins to identify the engine version.

This PR allows any valid API credentials (i.e. irrespective of allowed categories or ACLs) or a user to access this route.

#### What should your reviewer look out for in this PR?

At the same time, this PR prevents unauthenticated access, as unauthenticated access to `/` can allow an attacker to use attack vectors based on the version of Elasticsearch.

#### Which issue(s) does this PR fix?

Dejavu allows sharing public URLs of hosted indexes. We use this for demos where API creds use have extremely limited access. However, not allowing `/` route to be accessed prevents a user from cloning an index as `abc` can't identify the Elasticsearch cluster version.

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
