### PR TITLE
Add support for `updated_at` in user and permission endpoints

### DIFF
--- a/model/permission/permission.go
+++ b/model/permission/permission.go
@@ -58,6 +58,7 @@ type Permission struct {
 	Excludes             []string              `json:"exclude_fields"`
 	Expired              bool                  `json:"expired"`
 	ReactiveSearchConfig *ReactiveSearchConfig `json:"reactivesearchConfig,omitempty"`
+	UpdatedAt            string                `json:"updated_at"`
 }
 
 // Limits defines the rate limits for each category.
@@ -324,6 +325,7 @@ func New(creator string, opts ...Options) (*Permission, error) {
 		Sources:    []string{"0.0.0.0/0"},
 		Referers:   []string{"*"},
 		CreatedAt:  time.Now().Format(time.RFC3339),
+		UpdatedAt:  time.Now().Format(time.RFC3339),
 		TTL:        -1,
 		Limits:     &defaultLimits,
 	}
@@ -363,6 +365,7 @@ func NewAdmin(creator string, opts ...Options) (*Permission, error) {
 		Sources:    []string{"0.0.0.0/0"},
 		Referers:   []string{"*"},
 		CreatedAt:  time.Now().Format(time.RFC3339),
+		UpdatedAt:  time.Now().Format(time.RFC3339),
 		TTL:        -1,
 		Limits:     &defaultAdminLimits,
 	}

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -38,6 +38,7 @@ type User struct {
 	Email            string              `json:"email"`
 	Indices          []string            `json:"indices"`
 	CreatedAt        string              `json:"created_at"`
+	UpdatedAt        string              `json:"updated_at"`
 	Sources          *[]string           `json:"sources"`
 }
 
@@ -157,6 +158,7 @@ func New(username, password string, opts ...Options) (*User, error) {
 		IsAdmin:   &isAdminFalse, // pointer to bool
 		Indices:   []string{},
 		CreatedAt: time.Now().Format(time.RFC3339),
+		UpdatedAt: time.Now().Format(time.RFC3339),
 		Sources:   &defaultSources,
 	}
 
@@ -191,6 +193,7 @@ func NewAdmin(username, password string, opts ...Options) (*User, error) {
 		Indices:        []string{"*"},
 		Sources:        &defaultSources,
 		CreatedAt:      time.Now().Format(time.RFC3339),
+		UpdatedAt:      time.Now().Format(time.RFC3339),
 	}
 
 	// run the options on it

--- a/plugins/permissions/handlers.go
+++ b/plugins/permissions/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -246,6 +247,9 @@ func (p *permissions) patchPermission() http.HandlerFunc {
 				return
 			}
 		}
+
+		// Set the updated_at for the permission
+		patch["updated_at"] = time.Now().Format(time.RFC3339)
 
 		_, err2 := p.es.patchPermission(req.Context(), username, patch)
 		if err2 == nil {

--- a/plugins/users/handlers.go
+++ b/plugins/users/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -218,6 +219,10 @@ func (u *Users) patchUser() http.HandlerFunc {
 			}
 			patch["password"] = string(hashedPassword)
 		}
+
+		// Set the updated_at field
+		patch["updated_at"] = time.Now().Format(time.RFC3339)
+
 		_, err2 := u.es.patchUser(req.Context(), username, patch)
 		if err2 == nil {
 			// Only update local state when proxy API has not been called

--- a/plugins/users/handlers.go
+++ b/plugins/users/handlers.go
@@ -343,6 +343,9 @@ func (u *Users) patchUserWithUsername() http.HandlerFunc {
 			patch["password"] = string(hashedPassword)
 		}
 
+		// Set the updated_at
+		patch["updated_at"] = time.Now().Format(time.RFC3339)
+
 		_, err2 := u.es.patchUser(req.Context(), username, patch)
 		if err2 == nil {
 			// Only update local state when proxy API has not been called


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

There was no field indicating when an users details or permissions have been updated. This PR adds a new field in all places necessary and sets it accordingly to be of use in the frontend.

### [Loom of changes](https://www.loom.com/share/410fc875726241c1b8ed7d27efe7ca1b)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
