### PR TITLE
feat(es_template): add dynamic mapping for geo_point

### DIFF
--- a/util/es_template.go
+++ b/util/es_template.go
@@ -258,6 +258,15 @@ func SetSystemIndexTemplate() error {
 					"type": "long"
 				}
 			}
+		},
+		{
+			"geo": {
+				"match_mapping_type": "object",
+				"match": "*location",
+				"mapping": {
+				  "type": "geo_point"
+				}
+			}
 		}],
 		"dynamic": true
 	}`


### PR DESCRIPTION
#### What does this do / why do we need it?

This template provides a sane default for assuming the data type as a `geo_point` when field's default type is `object` and it ends with the word `location`

#### What should your reviewer look out for in this PR?

A potential side-effect is when the data is not clean or not of geo_point type. However, changing the type from geo_point to object is already supported via the Schema UI view.
