### PR TITLE
Fix an issue with not returning error for blacklisted endpoints

### DIFF
--- a/util/billing.go
+++ b/util/billing.go
@@ -194,6 +194,7 @@ func BillingMiddleware(next http.Handler) http.Handler {
 		for _, route := range BillingBlacklistedPaths() {
 			if strings.HasPrefix(requestURI, route) {
 				next.ServeHTTP(w, r)
+				return
 			}
 		}
 

--- a/util/offline_billing.go
+++ b/util/offline_billing.go
@@ -37,6 +37,7 @@ func BillingMiddlewareOffline(next http.Handler) http.Handler {
 		for _, route := range BillingBlacklistedPaths() {
 			if strings.HasPrefix(requestURI, route) {
 				next.ServeHTTP(w, r)
+				return
 			}
 		}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The methods that checks for whether or not payment is made are supposed to return after calling the `next` middleware in the flow after a blacklisted URL is matched.

This is not being done right now and as a result the response body is appended with some extra data even on blacklisted endpoints.

This PR fixes that issue.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
