### PR TITLE
Add support to build all pre-baked images on a published release

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -14,4 +14,3 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: appbaseio-confidential/elasticsearch-packer-build
           event-type: new_release
-          

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -1,0 +1,17 @@
+name: Send Build Image Event
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  send_event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Repo Dispatch Event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: appbaseio-confidential/elasticsearch-packer-build
+          event-type: new_release
+          


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support to send an event `new_release` to the repo that contains our pre-baked release code.

It uses the [repository dispatch](https://github.com/peter-evans/repository-dispatch) action to do so which in order invokes an workflow in the said repository that builds all the images and sets them accordingly.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
