### PR TITLE
Fix warnings to use composable templates because of using `*` in `index_patterns`

### DIFF
--- a/util/es_template.go
+++ b/util/es_template.go
@@ -198,12 +198,12 @@ func SetDefaultIndexTemplate() error {
 			"priority": 10
 		}`, settings, mappings)
 
-		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("arc_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())
+		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("rs_api_user_template_v2").BodyString(defaultSettingIndex).Do(context.Background())
 		if indexTemplateErr != nil {
 			// Try to create the template using IndexPutTemplate since Index template is
 			// supported from v7.8
 			log.Debug(fmt.Sprintf("Creating Index Template failed with error: %s, trying to create legacy template", indexTemplateErr))
-			_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSettingLegacy).Do(context.Background())
+			_, err := GetClient7().IndexPutTemplate("rs_api_user_template_v2").BodyString(defaultSettingLegacy).Do(context.Background())
 
 			if err != nil {
 				log.Errorln("[SET USER INDEX TEMPLATE ERROR V7]", ": ", err)
@@ -221,7 +221,7 @@ func SetDefaultIndexTemplate() error {
 			},
 			"order": 10
 		}`, settings, mappings)
-		_, err := GetClient6().IndexPutTemplate("arc_index_template_v1").BodyString(defaultSetting).Do(context.Background())
+		_, err := GetClient6().IndexPutTemplate("rs_api_user_template_v2").BodyString(defaultSetting).Do(context.Background())
 		if err != nil {
 			log.Errorln("[SET USER INDEX TEMPLATE ERROR V6]", ": ", err)
 			return err
@@ -306,12 +306,12 @@ func SetSystemIndexTemplate() error {
 			"priority": 100
 		}`, settings, mappings)
 
-		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("system_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())
+		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("rs_api_system_template_v2").BodyString(defaultSettingIndex).Do(context.Background())
 		if indexTemplateErr != nil {
 			// Try to create the template using IndexPutTemplate since Index template is
 			// supported from v7.8
 			log.Debug(fmt.Sprintf("Creating Index Template failed with error: %s, trying to create legacy template", indexTemplateErr))
-			_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSettingLegacy).Do(context.Background())
+			_, err := GetClient7().IndexPutTemplate("rs_api_system_template_v2").BodyString(defaultSettingLegacy).Do(context.Background())
 
 			if err != nil {
 				log.Errorln("[SET SYSTEM INDEX TEMPLATE ERROR V7]", ": ", err)
@@ -329,7 +329,7 @@ func SetSystemIndexTemplate() error {
 			},
 			"order": 10
 		}`, settings, mappings)
-		_, err := GetClient6().IndexPutTemplate("system_index_template_v1").BodyString(defaultSetting).Do(context.Background())
+		_, err := GetClient6().IndexPutTemplate("rs_api_system_template_v2").BodyString(defaultSetting).Do(context.Background())
 		if err != nil {
 			log.Errorln("[SET SYSTEM INDEX TEMPLATE ERROR V6]", ": ", err)
 			return err

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -190,12 +190,12 @@ func SetDefaultIndexTemplate() error {
 		}`, settings, mappings)
 
 		defaultSettingIndex := fmt.Sprintf(`{
-			"index_patterns": [".*"],
+			"index_patterns": ["*"],
 			"template": {
 				"settings": %s,
 				"mappings": %s
 			},
-			"priority": 1
+			"priority": 10
 		}`, settings, mappings)
 
 		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("arc_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())
@@ -298,12 +298,12 @@ func SetSystemIndexTemplate() error {
 		}`, settings, mappings)
 
 		defaultSettingIndex := fmt.Sprintf(`{
-			"index_patterns": [".*"],
+			"index_patterns": [".actionableinsights*", ".analytics*", ".cache*", ".publickey*", ".pipelines*", ".pipeline_vars*", ".pipeline_logs*", ".pipeline_invocations*", ".permissions*", ".logs*", ".rules*", ".searchgrader*", ".searchrelevancy*", ".storedquery*", ".suggestions*", ".suggestions_preferences*", ".sync_preferences*", ".synonyms*", ".uibuilder_preferences*", ".user_sessions*", ".users*"],
 			"template": {
 				"settings": %s,
 				"mappings": %s
 			},
-			"priority": 2
+			"priority": 100
 		}`, settings, mappings)
 
 		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("system_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -193,7 +193,7 @@ func SetDefaultIndexTemplate() error {
 			"index_patterns": [".*"],
 			"template": {
 				"settings": %s,
-				"mappings": %s,
+				"mappings": %s
 			},
 			"priority": 1
 		}`, settings, mappings)
@@ -301,7 +301,7 @@ func SetSystemIndexTemplate() error {
 			"index_patterns": [".*"],
 			"template": {
 				"settings": %s,
-				"mappings": %s,
+				"mappings": %s
 			},
 			"priority": 2
 		}`, settings, mappings)

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -195,7 +195,7 @@ func SetDefaultIndexTemplate() error {
 				"settings": %s,
 				"mappings": %s,
 			},
-			"priority": 2
+			"priority": 1
 		}`, settings, mappings)
 
 		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("arc_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -201,7 +201,7 @@ func SetDefaultIndexTemplate() error {
 		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("arc_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())
 		if indexTemplateErr != nil {
 			// Try to create the template using IndexPutTemplate since Index template is
-			// supported from v7.9
+			// supported from v7.8
 			log.Debug(fmt.Sprintf("Creating Index Template failed with error: %s, trying to create legacy template", indexTemplateErr))
 			_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSettingLegacy).Do(context.Background())
 
@@ -309,7 +309,7 @@ func SetSystemIndexTemplate() error {
 		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("system_index_template_v1").BodyString(defaultSettingIndex).Do(context.Background())
 		if indexTemplateErr != nil {
 			// Try to create the template using IndexPutTemplate since Index template is
-			// supported from v7.9
+			// supported from v7.8
 			log.Debug(fmt.Sprintf("Creating Index Template failed with error: %s, trying to create legacy template", indexTemplateErr))
 			_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSettingLegacy).Do(context.Background())
 

--- a/util/es_template.go
+++ b/util/es_template.go
@@ -279,10 +279,17 @@ func SetSystemIndexTemplate() error {
 			"mappings": %s,
 			"order": 20
 		}`, settings, mappings)
-		_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSetting).Do(context.Background())
-		if err != nil {
-			log.Errorln("[SET SYSTEM INDEX TEMPLATE ERROR V7]", ": ", err)
-			return err
+		_, indexTemplateErr := GetClient7().IndexPutIndexTemplate("system_index_template_v1").BodyString(defaultSetting).Do(context.Background())
+		if indexTemplateErr != nil {
+			// Try to create the template using IndexPutTemplate since Index template is
+			// supported from v7.9
+			log.Debug(fmt.Sprintf("Creating Index Template failed with error: %s, trying to create legacy template", indexTemplateErr))
+			_, err := GetClient7().IndexPutTemplate("system_index_template_v1").BodyString(defaultSetting).Do(context.Background())
+
+			if err != nil {
+				log.Errorln("[SET SYSTEM INDEX TEMPLATE ERROR V7]", ": ", err)
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

There were errors recently that indicated the template system has changed and the older template system is considered legacy now.

This PR fixes all those errors by creating the templates as index templates and as a fallback as legacy templates. This makes sure that both ES 7.8+ (supports index templates) and older versions (does not support index template, hence legacy as a fallback) are supported properly.

### [Loom of changes and tests done](https://www.loom.com/share/d593c557c3da4723a52930e316b7f6a2)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
