### PR TITLE
Update README to use ES 8 in local deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ In order to run `reactivesearch-api`, you'll require an Elasticsearch node. Ther
 
 1. Create a docker network
 
-        docker network create reactivesearch
+```sh
+docker network create reactivesearch
+```
 
 2. Start a single node Elasticsearch cluster locally
 
@@ -47,7 +49,9 @@ docker run -d --rm --name elasticsearch -p 9200:9200 -p 9300:9300 --net=reactive
 
 3. Start ReactiveSearch locally
 
-        docker build -t reactivesearch . && docker run --rm --name reactivesearch -p 8000:8000 --net=reactivesearch --env-file=config/docker.env reactivesearch
+```sh
+docker build -t reactivesearch . && docker run --rm --name reactivesearch -p 8000:8000 --net=reactivesearch --env-file=config/docker.env reactivesearch
+```
 
 For convenience, the steps described above are combined into a single `docker-compose` file. You can execute the file with command:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ In order to run `reactivesearch-api`, you'll require an Elasticsearch node. Ther
 
 2. Start a single node Elasticsearch cluster locally
 
-        docker run -d --rm --name elasticsearch -p 9200:9200 -p 9300:9300 --net=reactivesearch -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+```sh
+docker run -d --rm --name elasticsearch -p 9200:9200 -p 9300:9300 --net=reactivesearch -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.1.2
+```
+
+> NOTE: It is advised to use `-e "xpack.security.enabled=false"` for local runs of ElasticSearch since otherwise ES is not available on :9200.
 
 3. Start ReactiveSearch locally
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker network create reactivesearch
 2. Start a single node Elasticsearch cluster locally
 
 ```sh
-docker run -d --rm --name elasticsearch -p 9200:9200 -p 9300:9300 --net=reactivesearch -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.1.2
+docker run -d --rm --name elasticsearch -p 9200:9200 -p 9300:9300 --net=reactivesearch -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.2.0
 ```
 
 > NOTE: It is advised to use `-e "xpack.security.enabled=false"` for local runs of ElasticSearch since otherwise ES is not available on :9200.


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The README as of now has a command to deploy ES `7.10.2` while testing `reactivesearch-api` locally. However, the current stable ElasticSearch version is `8.1.3`.

This PR updates the README to suggest deploying ES `8.1.2` along with a note about disabling `xpack.security` to make sure ES is aceessible on `:9200`.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
