### PR TITLE
fix(docker): adds an additional check for docker runtime detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1 as builder
+FROM golang:1.18.2 as builder
 
 # Default value
 # Run `--build-arg BILLING=true` to enable billing


### PR DESCRIPTION
#### What does this do / why do we need it?

This PR adds an additional check based on inodes count to detect for a docker runtime on non-lxc systems. For example, prior to this change, running Docker on Mac wasn't being effectively detected.

Additionally, on a non-lxc system (not expected to run in production), the id will return as empty as `/proc/self/cgroup` won't be accessible or present. So this PR removes that check.

#### What should your reviewer look out for in this PR?

This PR should be side-effect free as it adds an additional condition to detect whether rs-api server is running in a container environment.

#### Which issue(s) does this PR fix?

This PR makes it easy to run the project as a Docker container.

It also updates Golang runtime to 1.18.2

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A