### PR TITLE
Add support to send image build event on stable releases only

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -5,8 +5,21 @@ on:
     types: [published]
 
 jobs:
-  send_event:
+  determine_whether_to_run:
     runs-on: ubuntu-latest
+    outputs:
+      send_event: ${{ steps.check-send-event.outputs.run_jobs }}
+
+    steps:
+      - name: Check if event should be sent
+        id: check-send-event
+        run: (echo "${{ github.ref }}" | grep -Eq  '^refs\/tags\/[0-9]+\.[0-9]+\.[0-9]+$') && echo "::set-output name=run_jobs::true" || echo "::set-output name=run_jobs::false"
+
+  send_event:
+    needs: determine_whether_to_run
+    runs-on: ubuntu-latest
+    if: needs.determine_whether_to_run.outputs.send_event == 'true'
+
     steps:
       - name: Send Repo Dispatch Event
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

There is an issue with beta releases where the releases are made `published` for a few minutes before it is marked as a `pre-release`. This is an issue since `published` releases send an event to build the `packer` images using a repo dispatch event.

This PR fixes that by adding a check that ensures that the event is sent only if the version is in the format `x.x.x` which means `8.1.0` will invoke it and `8.1.0.beta1` will not invoke it.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
