### PR TITLE
fix(log path): use local dir instead of global dir for default log paths

### DIFF
--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -16,7 +16,7 @@ const (
 	defaultLogsEsIndex = ".logs"
 	envEsURL           = "ES_CLUSTER_URL"
 	envLogsEsIndex     = "LOGS_ES_INDEX"
-	defaultLogFilePath = "/var/log/arc/es.json"
+	defaultLogFilePath = "log/arc/es.json"
 	envLogFilePath     = "LOG_FILE_PATH"
 	config             = `
 	{

--- a/plugins/telemetry/telemetry.go
+++ b/plugins/telemetry/telemetry.go
@@ -21,7 +21,7 @@ const (
 	syncInterval             = 10  // interval in minutes to sync telemetry records
 	deltaInterval            = 100 // in ms
 	totalEventsPerRequest    = 2000
-	defaultTelemetryFilePath = "/var/log/arc/telemetry"
+	defaultTelemetryFilePath = "log/arc/telemetry"
 	envTelemetryFilePath     = "TELEMETRY_FILE_PATH" // Just for local testing
 )
 


### PR DESCRIPTION
#### What does this do / why do we need it?

Use local dir `log/arc/...` instead of global dir `/var/log/arc/...` as a default log path

#### What should your reviewer look out for in this PR?

- [x] Test by defining no log paths in config and the service should start up

#### Which issue(s) does this PR fix?

This would reduce the friction of defining default configs to startup the rs-api service.

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
