### PR TITLE
Make changes to send the packer event after artifact build

### DIFF
--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -2,6 +2,7 @@ name: build binary
 on:
   release:
     types: [published]
+
 jobs:
   build:
     name: Build
@@ -46,3 +47,11 @@ jobs:
           envs: VERSION
           script: |
             sh build.sh ${VERSION} > build.log 2>&1 &
+  
+  send-packer-event:
+    name: Send Packer Event
+    runs-on: ubuntu-latest
+    needs: build
+    uses: ./.github/workflows/build_images.yml
+    with:
+      ref: ${{ github.ref }}

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -1,8 +1,11 @@
 name: Send Build Image Event
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
 
 jobs:
   determine_whether_to_run:
@@ -13,7 +16,7 @@ jobs:
     steps:
       - name: Check if event should be sent
         id: check-send-event
-        run: (echo "${{ github.ref }}" | grep -Eq  '^refs\/tags\/[0-9]+\.[0-9]+\.[0-9]+$') && echo "::set-output name=run_jobs::true" || echo "::set-output name=run_jobs::false"
+        run: (echo "${{ inputs.ref }}" | grep -Eq  '^refs\/tags\/[0-9]+\.[0-9]+\.[0-9]+$') && echo "::set-output name=run_jobs::true" || echo "::set-output name=run_jobs::false"
 
   send_event:
     needs: determine_whether_to_run


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

Since the released builds use an workflow to add artifacts, it is important that the packer build event is sent only after the artifacts are successfully added.

This PR changes the send_event workflow into a reusable one and uses it in the `binary-publish` workflow by requiring the binary builds to complete first.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
