### PR TITLE
Add init changes to throw error for highlight and config

### DIFF
--- a/plugins/querytranslate/middleware.go
+++ b/plugins/querytranslate/middleware.go
@@ -267,8 +267,8 @@ func queryTranslate(h http.HandlerFunc) http.HandlerFunc {
 
 		// log.Println("RS QUERY", msearchQuery)
 		if translateErr != nil {
-			log.Errorln(logTag, ":", err)
-			telemetry.WriteBackErrorWithTelemetry(req, w, err.Error(), http.StatusBadRequest)
+			log.Errorln(logTag, ":", translateErr)
+			telemetry.WriteBackErrorWithTelemetry(req, w, translateErr.Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -42,6 +42,11 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 			return "", errors.New("field 'dataField' can not have multiple fields for 'term' or 'geo' queries")
 		}
 
+		// Validate highlight and highlightConfig
+		if query.HighlightConfig != nil && (query.Highlight == nil || !*query.Highlight) {
+			return "", errors.New("`highlightConfig` will be ignored when `highlight` is not passed or set to `false`")
+		}
+
 		// Normalize query value for search and suggestion types of queries
 		if query.Type == Search || query.Type == Suggestion {
 			if query.Value != nil {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds a functionality to throw an error if `highlight` is not passed or `false` and `highlightConfig` is passed.

#### [Loom showing the feature in action](https://www.loom.com/share/5a7dc031c49e49acaf0ef7ca1e8984b1)

### Testing Steps:

Following request should throw an error:

```sh
curl --location --request POST 'http://foo:bar@localhost:8000/good-books-ds/_reactivesearch.v3' \
--header 'Content-Type: application/json' \
--data-raw '{
    "query": [
        {
            "id": "test",
            "value": "test",
            "dataField": "original_title.autosuggest",
            "highlight": false,
            "highlightConfig": {
                "fields": {
                    "title": {}
                },
                "pre_tags": [
                    "<pre>"
                ],
                "post_tags": [
                    "</pre>"
                ],
                "require_field_match": false
            }
        }
    ]
}'
```

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
