### PR TITLE
Add support for returning active nodes count in health

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/plugins"
+	"github.com/appbaseio/reactivesearch-api/plugins/nodes"
 	"github.com/appbaseio/reactivesearch-api/util"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/getsentry/sentry-go"
@@ -540,6 +541,13 @@ func main() {
 	routerHealthCronJob := cron.New()
 	routerHealthCronJob.AddFunc("@every 10s", routerHealthCheck.Check)
 	routerHealthCronJob.Start()
+
+	// Start the job to keep pinging ES to mark as live node
+	log.Info(logTag, ": setting up active node ping job")
+	nodeInstance := nodes.Instance()
+	pingESJob := cron.New()
+	pingESJob.AddFunc("@every 10s", nodeInstance.PingESWithTime)
+	pingESJob.Start()
 
 	// Finally start the server
 	routerSwapper.StartServer()

--- a/main.go
+++ b/main.go
@@ -546,7 +546,7 @@ func main() {
 	log.Info(logTag, ": setting up active node ping job")
 	nodeInstance := nodes.Instance()
 	pingESJob := cron.New()
-	pingESJob.AddFunc("@every 10s", nodeInstance.PingESWithTime)
+	pingESJob.AddFunc("@every 1m", nodeInstance.PingESWithTime)
 	pingESJob.Start()
 
 	// Finally start the server

--- a/main.go
+++ b/main.go
@@ -543,11 +543,9 @@ func main() {
 	routerHealthCronJob.Start()
 
 	// Start the job to keep pinging ES to mark as live node
-	log.Info(logTag, ": setting up active node ping job")
+	log.Info(logTag, ": setting up active node ping jobs")
 	nodeInstance := nodes.Instance()
-	pingESJob := cron.New()
-	pingESJob.AddFunc("@every 1m", nodeInstance.PingESWithTime)
-	pingESJob.Start()
+	nodeInstance.StartAutomatedJobs()
 
 	// Finally start the server
 	routerSwapper.StartServer()

--- a/plugins/elasticsearch/handlers.go
+++ b/plugins/elasticsearch/handlers.go
@@ -146,21 +146,3 @@ func (es *elasticsearch) pingES() http.HandlerFunc {
 		util.WriteBackRaw(w, responseInBytes, code)
 	}
 }
-
-// dryHealthCheck will return a dummy response everytime it's
-// called. This method can be used to check if the server is stuck
-// and whether or not a restart is necessary.
-func dryHealthCheck() http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		response := map[string]interface{}{
-			"health": "ok",
-		}
-
-		// Marshal the response
-		//
-		// NOTE: No need to check error since response is manually created
-		// in the above lines
-		responseInBytes, _ := json.Marshal(response)
-		util.WriteBackRaw(w, responseInBytes, http.StatusOK)
-	}
-}

--- a/plugins/elasticsearch/routes.go
+++ b/plugins/elasticsearch/routes.go
@@ -117,14 +117,7 @@ func (es *elasticsearch) preprocess(mw []middleware.Middleware) error {
 		HandlerFunc: es.healthCheck(),
 		Description: "Retrieve the cluster health, both appbase.io and Elasticsearch",
 	}
-	dryHealthCheckRoute := plugins.Route{
-		Name:        "Dry Health Check",
-		Methods:     []string{http.MethodGet, http.MethodHead, http.MethodPost},
-		Path:        "/arc/_health",
-		HandlerFunc: dryHealthCheck(),
-		Description: "Return a dummy response to indicate routers are working",
-	}
-	routes = append(routes, indexRoute, healthCheckRoute, dryHealthCheckRoute)
+	routes = append(routes, indexRoute, healthCheckRoute)
 	return nil
 }
 

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -60,3 +60,9 @@ func (es *elasticsearch) deleteOlderRecords(ctx context.Context) error {
 func (es *elasticsearch) activeNodesInTenMins(ctx context.Context) (int64, error) {
 	return es.activeNodesInTenMins7(ctx)
 }
+
+// activeNodesInSevenDays will get the number of active nodes in the last
+// 7 days.
+func (es *elasticsearch) activeNodesInSevenDays(ctx context.Context) (int64, error) {
+	return es.activeNodesInSevenDays7(ctx)
+}

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -1,0 +1,46 @@
+package nodes
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/appbaseio/reactivesearch-api/util"
+)
+
+type elasticsearch struct {
+	indexName string
+	mapping   string
+}
+
+func initPlugin(indexName, mapping string) (*elasticsearch, error) {
+	ctx := context.Background()
+
+	es := &elasticsearch{indexName, mapping}
+
+	// Check if the meta index already exists
+	exists, err := util.GetClient7().IndexExists(indexName).
+		Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: error while checking if index already exists: %v", logTag, err)
+	}
+	if exists {
+		log.Println(logTag, ": index named", indexName, "already exists, skipping...")
+		return es, nil
+	}
+
+	replicas := util.GetReplicas()
+	settings := fmt.Sprintf(mapping, util.HiddenIndexSettings(), replicas)
+
+	// Create a new meta index
+	_, err = util.GetClient7().CreateIndex(indexName).
+		Body(settings).
+		Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: error while creating index named %s: %v", logTag, indexName, err)
+	}
+
+	log.Println(logTag, ": successfully created index named", indexName)
+	return es, nil
+}

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -49,3 +49,8 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 func (es *elasticsearch) pingES(ctx context.Context, machineID string) error {
 	return es.pingES7(ctx, machineID)
 }
+
+// deleteOlderRecords will delete all records older than 7 days
+func (es *elasticsearch) deleteOlderRecords(ctx context.Context) error {
+	return es.deleteOlderRecords7(ctx)
+}

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -46,6 +46,6 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 }
 
 // pingES will ping ElasticSearch with the machine ID and the current time
-func (es *elasticsearch) pingES(machineID string) error {
-	return es.pingES7(machineID)
+func (es *elasticsearch) pingES(ctx context.Context, machineID string) error {
+	return es.pingES7(ctx, machineID)
 }

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -44,3 +44,8 @@ func initPlugin(indexName, mapping string) (*elasticsearch, error) {
 	log.Println(logTag, ": successfully created index named", indexName)
 	return es, nil
 }
+
+// pingES will ping ElasticSearch with the machine ID and the current time
+func (es *elasticsearch) pingES(machineID string) error {
+	return es.pingES7(machineID)
+}

--- a/plugins/nodes/dao.go
+++ b/plugins/nodes/dao.go
@@ -54,3 +54,9 @@ func (es *elasticsearch) pingES(ctx context.Context, machineID string) error {
 func (es *elasticsearch) deleteOlderRecords(ctx context.Context) error {
 	return es.deleteOlderRecords7(ctx)
 }
+
+// activeNodesInTenMins will get the number of active nodes in the last
+// 10 mins.
+func (es *elasticsearch) activeNodesInTenMins(ctx context.Context) (int64, error) {
+	return es.activeNodesInTenMins7(ctx)
+}

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -44,7 +44,7 @@ func (es *elasticsearch) pingES7(ctx context.Context, machineID string) error {
 //
 // We don't need to keep docs older than 7 days since we only need the node
 // count of the last 10 mins and the last 7 days.
-func (es *elasticsearch) deleteOlderRecords(ctx context.Context, machineID string) error {
+func (es *elasticsearch) deleteOlderRecords7(ctx context.Context) error {
 	// Get the minimum time allowed.
 	// We will get the current time - 7 days
 	minTime := time.Now().AddDate(0, 0, -7).Unix()

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -45,11 +45,11 @@ func (es *elasticsearch) pingES7(ctx context.Context, machineID string) error {
 // We don't need to keep docs older than 7 days since we only need the node
 // count of the last 10 mins and the last 7 days.
 func (es *elasticsearch) deleteOlderRecords7(ctx context.Context) error {
-	// Get the minimum time allowed.
+	// Get the maximum time allowed.
 	// We will get the current time - 7 days
-	minTime := time.Now().AddDate(0, 0, -7).Unix()
+	maxTime := time.Now().AddDate(0, 0, -7).Unix()
 
-	rangeQuery := es7.NewRangeQuery("ping_time").Lt(minTime)
+	rangeQuery := es7.NewRangeQuery("ping_time").Lt(maxTime)
 
 	_, err := util.GetClient7().DeleteByQuery().Index(es.indexName).Query(rangeQuery).Do(ctx)
 	if err != nil {

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -80,12 +80,12 @@ func (es *elasticsearch) activeNodesInTenMins7(ctx context.Context) (int64, erro
 	return resp, nil
 }
 
-// activeNodesInSevenDays will return the number of active nodes in the last
+// activeNodesInSevenDays7 will return the number of active nodes in the last
 // 7 days using the current time stamp and making a query against the nodes index.
 //
 // All docs that have `ping_time` set as greater than the last 7 days will be
 // fetched using this function and counted.
-func (es *elasticsearch) activeNodesInSevenDays(ctx context.Context) (int64, error) {
+func (es *elasticsearch) activeNodesInSevenDays7(ctx context.Context) (int64, error) {
 	minTime := time.Now().AddDate(0, 0, -7).Unix()
 
 	rangeQuery := es7.NewRangeQuery("ping_time").Gte(minTime)

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/appbaseio/reactivesearch-api/util"
+	es7 "github.com/olivere/elastic/v7"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,5 +36,26 @@ func (es *elasticsearch) pingES7(ctx context.Context, machineID string) error {
 		log.Errorln(logTag, ": error indexing ping time:", err)
 		return err
 	}
+	return nil
+}
+
+// deleteOlderRecords will ping ElasticSearch with a delete_by_query request
+// where range will be used to delete records older than 7 days.
+//
+// We don't need to keep docs older than 7 days since we only need the node
+// count of the last 10 mins and the last 7 days.
+func (es *elasticsearch) deleteOlderRecords(ctx context.Context, machineID string) error {
+	// Get the minimum time allowed.
+	// We will get the current time - 7 days
+	minTime := time.Now().AddDate(0, 0, -7).Unix()
+
+	rangeQuery := es7.NewRangeQuery("ping_time").Lt(minTime)
+
+	_, err := util.GetClient7().DeleteByQuery().Index(es.indexName).Query(rangeQuery).Do(ctx)
+	if err != nil {
+		log.Errorln(logTag, ": error while deleting records older than 7 days, ", err)
+		return err
+	}
+
 	return nil
 }

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -1,11 +1,41 @@
 package nodes
 
+import (
+	"context"
+
+	"github.com/appbaseio/reactivesearch-api/util"
+)
+
 // pingES7 will ping ElasticSearch based on the passed machine ID
 // with the current unix timestamp.
 //
 // This function will also determine whether the document should
 // be created or updated based on the machineID being present
 // or not being present in ES.
-func (es *elasticsearch) pingES7(machineID string) error {
+func (es *elasticsearch) pingES7(ctx context.Context, machineID string) error {
+	// Check if the ID already exists
+	idExists, err := es.machineExists(ctx, machineID)
+	if err != nil {
+		return err
+	}
+
+	if idExists {
+		// Update the ping time
+	} else {
+		// Create a new doc with ping time
+	}
+
 	return nil
+}
+
+// machineExists will check if the machineID exists in the index
+// using the exists query provided by elasticsearch
+func (es *elasticsearch) machineExists(ctx context.Context, machineID string) (bool, error) {
+	response, err := util.GetClient7().Get().Index(es.indexName).Id(machineID).Do(ctx)
+
+	if err != nil {
+		return false, err
+	}
+
+	return response != nil, nil
 }

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -79,3 +79,22 @@ func (es *elasticsearch) activeNodesInTenMins7(ctx context.Context) (int64, erro
 
 	return resp, nil
 }
+
+// activeNodesInSevenDays will return the number of active nodes in the last
+// 7 days using the current time stamp and making a query against the nodes index.
+//
+// All docs that have `ping_time` set as greater than the last 7 days will be
+// fetched using this function and counted.
+func (es *elasticsearch) activeNodesInSevenDays(ctx context.Context) (int64, error) {
+	minTime := time.Now().AddDate(0, 0, -7).Unix()
+
+	rangeQuery := es7.NewRangeQuery("ping_time").Gte(minTime)
+
+	nodeCount, err := util.GetClient7().Count().Index(es.indexName).Query(rangeQuery).Do(ctx)
+	if err != nil {
+		log.Errorln(logTag, ": error while getting the number of active nodes in the last 7 days, ", err)
+		return 0, err
+	}
+
+	return nodeCount, err
+}

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/appbaseio/reactivesearch-api/util"
-	"github.com/prometheus/common/log"
+	log "github.com/sirupsen/logrus"
 )
 
 // pingES7 will ping ElasticSearch based on the passed machine ID

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -67,7 +67,7 @@ func (es *elasticsearch) deleteOlderRecords7(ctx context.Context) error {
 // All docs that have `ping_time` set as greater than the last 10 mins will
 // be fetched using this function and counted.
 func (es *elasticsearch) activeNodesInTenMins7(ctx context.Context) (int64, error) {
-	minTime := time.Now().Add(time.Minute * -10)
+	minTime := time.Now().Add(time.Minute * -10).Unix()
 
 	rangeQuery := es7.NewRangeQuery("ping_time").Gte(minTime)
 

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -1,0 +1,11 @@
+package nodes
+
+// pingES7 will ping ElasticSearch based on the passed machine ID
+// with the current unix timestamp.
+//
+// This function will also determine whether the document should
+// be created or updated based on the machineID being present
+// or not being present in ES.
+func (es *elasticsearch) pingES7(machineID string) error {
+	return nil
+}

--- a/plugins/nodes/dao_es7.go
+++ b/plugins/nodes/dao_es7.go
@@ -59,3 +59,23 @@ func (es *elasticsearch) deleteOlderRecords7(ctx context.Context) error {
 
 	return nil
 }
+
+// activeNodesInTenMins will return the number of active nodes in the last
+// 10 mins using the current time stamp and making a query against the
+// nodes index.
+//
+// All docs that have `ping_time` set as greater than the last 10 mins will
+// be fetched using this function and counted.
+func (es *elasticsearch) activeNodesInTenMins7(ctx context.Context) (int64, error) {
+	minTime := time.Now().Add(time.Minute * -10)
+
+	rangeQuery := es7.NewRangeQuery("ping_time").Gte(minTime)
+
+	resp, err := util.GetClient7().Count().Index(es.indexName).Query(rangeQuery).Do(ctx)
+	if err != nil {
+		log.Errorln(logTag, ": error while getting number of active nodes in the last 10 mins, ", err)
+		return 0, err
+	}
+
+	return resp, nil
+}

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -16,6 +16,8 @@ func healtCheckNodes() http.HandlerFunc {
 			"health": "ok",
 		}
 
+		// TODO: Add the node counts after fetching it from ES
+
 		// Marshal the response
 		//
 		// NOTE: No need to check error since response is manually created

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -1,0 +1,26 @@
+package nodes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/appbaseio/reactivesearch-api/util"
+)
+
+// healtCheckNodes will return the health status of the node
+// along with the number of active nodes in the last 10 mins
+// and the last 7 days.
+func healtCheckNodes() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		response := map[string]interface{}{
+			"health": "ok",
+		}
+
+		// Marshal the response
+		//
+		// NOTE: No need to check error since response is manually created
+		// in the above lines
+		responseInBytes, _ := json.Marshal(response)
+		util.WriteBackRaw(w, responseInBytes, http.StatusOK)
+	}
+}

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -5,18 +5,26 @@ import (
 	"net/http"
 
 	"github.com/appbaseio/reactivesearch-api/util"
+	log "github.com/sirupsen/logrus"
 )
 
 // healtCheckNodes will return the health status of the node
 // along with the number of active nodes in the last 10 mins
 // and the last 7 days.
-func healtCheckNodes() http.HandlerFunc {
+func (n *nodes) healtCheckNodes() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		response := map[string]interface{}{
-			"health": "ok",
+		response := ArcHealthResponse{
+			Health: "ok",
 		}
 
 		// TODO: Add the node counts after fetching it from ES
+		activeTenMins, err := n.es.activeNodesInTenMins(req.Context())
+		if err != nil {
+			log.Warnln(logTag, ": error while getting the active node count for ten mins, ", err)
+			activeTenMins = 0
+		}
+
+		response.NodeCount = activeTenMins
 
 		// Marshal the response
 		//

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -8,10 +8,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// healtCheckNodes will return the health status of the node
+// healthCheckNodes will return the health status of the node
 // along with the number of active nodes in the last 10 mins
 // and the last 7 days.
-func (n *nodes) healtCheckNodes() http.HandlerFunc {
+func (n *nodes) healthCheckNodes() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		response := ArcHealthResponse{
 			Health: "ok",

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -17,7 +17,7 @@ func (n *nodes) healtCheckNodes() http.HandlerFunc {
 			Health: "ok",
 		}
 
-		// TODO: Add the node counts after fetching it from ES
+		// Add the node counts after fetching it from ES
 		activeTenMins, err := n.es.activeNodesInTenMins(req.Context())
 		if err != nil {
 			log.Warnln(logTag, ": error while getting the active node count for ten mins, ", err)
@@ -25,6 +25,15 @@ func (n *nodes) healtCheckNodes() http.HandlerFunc {
 		}
 
 		response.NodeCount = activeTenMins
+
+		// Add the node count for last 7 days from ES
+		activeSevenDays, err := n.es.activeNodesInSevenDays(req.Context())
+		if err != nil {
+			log.Warnln(logTag, ": error while getting the active node count for seven days, ", err)
+			activeSevenDays = 0
+		}
+
+		response.NodeCountSeven = activeSevenDays
 
 		// Marshal the response
 		//

--- a/plugins/nodes/main/nodes.go
+++ b/plugins/nodes/main/nodes.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"github.com/appbaseio/reactivesearch-api/plugins"
+	"github.com/appbaseio/reactivesearch-api/plugins/nodes"
+)
+
+var PluginInstance plugins.Plugin = nodes.Instance()

--- a/plugins/nodes/middleware.go
+++ b/plugins/nodes/middleware.go
@@ -1,0 +1,19 @@
+package nodes
+
+import (
+	"net/http"
+
+	"github.com/appbaseio/reactivesearch-api/middleware"
+)
+
+type chain struct {
+	middleware.Fifo
+}
+
+func (c *chain) Wrap(h http.HandlerFunc) http.HandlerFunc {
+	return c.Adapt(h, list()...)
+}
+
+func list() []middleware.Middleware {
+	return []middleware.Middleware{}
+}

--- a/plugins/nodes/nodes.go
+++ b/plugins/nodes/nodes.go
@@ -1,5 +1,13 @@
 package nodes
 
+import (
+	"sync"
+
+	"github.com/appbaseio/reactivesearch-api/middleware"
+	"github.com/appbaseio/reactivesearch-api/plugins"
+	log "github.com/sirupsen/logrus"
+)
+
 const (
 	logTag            = "[nodes]"
 	defaultNodesIndex = ".nodes"
@@ -7,3 +15,52 @@ const (
 	envEsURL          = "ES_CLUSTER_URL"
 	settings          = `{ "settings" : { %s "index.number_of_shards" : 1, "index.number_of_replicas" : %d } }`
 )
+
+var (
+	singleton *nodes
+	once      sync.Once
+)
+
+type nodes struct {
+	es nodeService
+}
+
+// Use only this function to fetch the instance of nodes from within
+// this package to avoid creating stateless duplicates of the plugin.
+func Instance() *nodes {
+	once.Do(func() { singleton = &nodes{} })
+	return singleton
+}
+
+func (n *nodes) Name() string {
+	return logTag
+}
+
+func (n *nodes) InitFunc() error {
+	log.Println(logTag, ": initializing plugin")
+
+	indexName := defaultNodesIndex
+
+	// initialize the dao
+	var err error
+	n.es, err = initPlugin(indexName, settings)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *nodes) Routes() []plugins.Route {
+	return n.routes()
+}
+
+// Default empty middleware array function
+func (n *nodes) ESMiddleware() []middleware.Middleware {
+	return make([]middleware.Middleware, 0)
+}
+
+// Default empty middleware array function
+func (n *nodes) RSMiddleware() []middleware.Middleware {
+	return make([]middleware.Middleware, 0)
+}

--- a/plugins/nodes/nodes.go
+++ b/plugins/nodes/nodes.go
@@ -1,0 +1,9 @@
+package nodes
+
+const (
+	logTag            = "[nodes]"
+	defaultNodesIndex = ".nodes"
+	typeName          = "_doc"
+	envEsURL          = "ES_CLUSTER_URL"
+	settings          = `{ "settings" : { %s "index.number_of_shards" : 1, "index.number_of_replicas" : %d } }`
+)

--- a/plugins/nodes/routes.go
+++ b/plugins/nodes/routes.go
@@ -12,7 +12,7 @@ func (n *nodes) routes() []plugins.Route {
 			Name:        "Arc Health Check",
 			Methods:     []string{http.MethodGet, http.MethodHead, http.MethodPost},
 			Path:        "/arc/_health",
-			HandlerFunc: healtCheckNodes(),
+			HandlerFunc: n.healtCheckNodes(),
 			Description: "Return detail about the current node as well as active nodes",
 		},
 	}

--- a/plugins/nodes/routes.go
+++ b/plugins/nodes/routes.go
@@ -1,8 +1,20 @@
 package nodes
 
-import "github.com/appbaseio/reactivesearch-api/plugins"
+import (
+	"net/http"
+
+	"github.com/appbaseio/reactivesearch-api/plugins"
+)
 
 func (n *nodes) routes() []plugins.Route {
-	routes := []plugins.Route{}
+	routes := []plugins.Route{
+		{
+			Name:        "Arc Health Check",
+			Methods:     []string{http.MethodGet, http.MethodHead, http.MethodPost},
+			Path:        "/arc/_health",
+			HandlerFunc: healtCheckNodes(),
+			Description: "Return detail about the current node as well as active nodes",
+		},
+	}
 	return routes
 }

--- a/plugins/nodes/routes.go
+++ b/plugins/nodes/routes.go
@@ -12,7 +12,7 @@ func (n *nodes) routes() []plugins.Route {
 			Name:        "Arc Health Check",
 			Methods:     []string{http.MethodGet, http.MethodHead, http.MethodPost},
 			Path:        "/arc/_health",
-			HandlerFunc: n.healtCheckNodes(),
+			HandlerFunc: n.healthCheckNodes(),
 			Description: "Return detail about the current node as well as active nodes",
 		},
 	}

--- a/plugins/nodes/routes.go
+++ b/plugins/nodes/routes.go
@@ -1,0 +1,8 @@
+package nodes
+
+import "github.com/appbaseio/reactivesearch-api/plugins"
+
+func (n *nodes) routes() []plugins.Route {
+	routes := []plugins.Route{}
+	return routes
+}

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -1,0 +1,1 @@
+package nodes

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -1,4 +1,7 @@
 package nodes
 
+import "context"
+
 type nodeService interface {
+	pingES(ctx context.Context, machineID string) error
 }

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -4,4 +4,5 @@ import "context"
 
 type nodeService interface {
 	pingES(ctx context.Context, machineID string) error
+	deleteOlderRecords(ctx context.Context) error
 }

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -5,4 +5,5 @@ import "context"
 type nodeService interface {
 	pingES(ctx context.Context, machineID string) error
 	deleteOlderRecords(ctx context.Context) error
+	activeNodesInTenMins(ctx context.Context) (int64, error)
 }

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -1,1 +1,4 @@
 package nodes
+
+type nodeService interface {
+}

--- a/plugins/nodes/service.go
+++ b/plugins/nodes/service.go
@@ -6,4 +6,5 @@ type nodeService interface {
 	pingES(ctx context.Context, machineID string) error
 	deleteOlderRecords(ctx context.Context) error
 	activeNodesInTenMins(ctx context.Context) (int64, error)
+	activeNodesInSevenDays(ctx context.Context) (int64, error)
 }

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -26,3 +26,9 @@ func (n *nodes) PingESWithTime() {
 		log.Errorln(logTag, ": error occurred while pinging ES to update time, ", err)
 	}
 }
+
+// DeleteOutdated will delete all the docs in the index
+// that are older than 7 days.
+func (n *nodes) DeleteOutdated() {
+
+}

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -23,6 +23,6 @@ func (n *nodes) PingESWithTime() {
 	err := n.es.pingES(context.Background(), machineID)
 
 	if err != nil {
-		log.Warnln(logTag, ": error occurred while pinging ES to update time, ", err)
+		log.Errorln(logTag, ": error occurred while pinging ES to update time, ", err)
 	}
 }

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -1,5 +1,28 @@
 package nodes
 
+import (
+	"context"
+
+	"github.com/appbaseio/reactivesearch-api/util"
+	log "github.com/sirupsen/logrus"
+)
+
 type ESNode struct {
 	PingTime *int64 `json:"ping_time"`
+}
+
+// PingESWithTime will ping ES with the timestamp
+// and the machine ID of the current node.
+//
+// It will also setup everything else like getting the
+// ES instance etc.
+func (n *nodes) PingESWithTime() {
+	// Get the machineID
+	machineID := util.MachineID
+
+	err := n.es.pingES(context.Background(), machineID)
+
+	if err != nil {
+		log.Warnln(logTag, ": error occurred while pinging ES to update time, ", err)
+	}
 }

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -30,5 +30,9 @@ func (n *nodes) PingESWithTime() {
 // DeleteOutdated will delete all the docs in the index
 // that are older than 7 days.
 func (n *nodes) DeleteOutdated() {
+	err := n.es.deleteOlderRecords(context.Background())
 
+	if err != nil {
+		log.Errorln(logTag, ": error while deleting outdated records, ", err)
+	}
 }

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -1,6 +1,5 @@
 package nodes
 
 type ESNode struct {
-	ID       *string `json:"_id"`
-	PingTime *int64  `json:"ping_time"`
+	PingTime *int64 `json:"ping_time"`
 }

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -12,6 +12,12 @@ type ESNode struct {
 	PingTime *int64 `json:"ping_time"`
 }
 
+type ArcHealthResponse struct {
+	Health         string `json:"health"`
+	NodeCount      int64  `json:"node_count"`
+	NodeCountSeven int64  `json:"node_count_7d"`
+}
+
 // PingESWithTime will ping ES with the timestamp
 // and the machine ID of the current node.
 //

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -1,0 +1,6 @@
+package nodes
+
+type ESNode struct {
+	ID       *string `json:"_id"`
+	PingTime *int64  `json:"ping_time"`
+}

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/appbaseio/reactivesearch-api/util"
+	"github.com/robfig/cron"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,4 +36,23 @@ func (n *nodes) DeleteOutdated() {
 	if err != nil {
 		log.Errorln(logTag, ": error while deleting outdated records, ", err)
 	}
+}
+
+// StartAutomatedJobs will start all jobs related to nodes
+// syncinc and deleting.
+//
+// This method will start the following jobs in the given
+// interval
+// - ping job: every 1m
+// - delete job: every 7d
+func (n *nodes) StartAutomatedJobs() {
+	// Start the ping job
+	pingESJob := cron.New()
+	pingESJob.AddFunc("@every 1m", n.PingESWithTime)
+	pingESJob.Start()
+
+	// Start the delete job
+	deleteNodeJob := cron.New()
+	deleteNodeJob.AddFunc("@every 7d", n.DeleteOutdated)
+	deleteNodeJob.Start()
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds the functionality of active nodes details being returned in the health endpoint. A sample active node response will be following:

```
{
  "health": "ok",
  "node_count": 1,
  "node_count_7d": 2
}
```

This adds two cronjobs that run in the background and silently does the following things:

1. ping ElasticSearch every 1 minute to update the current node as active -> run every `1 minute`
2. delete records older than 7 days -> runs every `7 days`

### [Loom of example tests and code walkthrough](https://www.loom.com/share/bcfc2aa98e43437dbd2776812fe85866)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
