### PR TITLE
Fix issue with build binary workflow failing

### DIFF
--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -50,7 +50,6 @@ jobs:
   
   send-packer-event:
     name: Send Packer Event
-    runs-on: ubuntu-latest
     needs: build
     uses: ./.github/workflows/build_images.yml
     with:


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The build binary workflow failed to build the assets because of an issue in the syntax. This PR fixes that issue.

`runs-on` cannot be used with `uses` and `with` in the workflow job description.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
