### PR TITLE
Fix an issue with reusable workflow not able to access `repo_access_token`.

### DIFF
--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -27,7 +27,7 @@ jobs:
         uses: hashicorp/packer-github-actions@master
         with:
           command: build
-          target: './ami.json'
+          target: "./ami.json"
         env:
           PACKER_LOG: 1
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
@@ -47,10 +47,11 @@ jobs:
           envs: VERSION
           script: |
             sh build.sh ${VERSION}
-  
+
   send-packer-event:
     name: Send Packer Event
     needs: build
     uses: ./.github/workflows/build_images.yml
     with:
       ref: ${{ github.ref }}
+      token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -6,6 +6,9 @@ on:
       ref:
         required: true
         type: string
+      token:
+        required: true
+        type: string
 
 jobs:
   determine_whether_to_run:
@@ -27,6 +30,6 @@ jobs:
       - name: Send Repo Dispatch Event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ inputs.token }}
           repository: appbaseio-confidential/elasticsearch-packer-build
           event-type: new_release


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

The reusable workflow that sends an event to build all the packer images needs a `repo_access_token` in order to send the event. This value was being read from secrets but reusable workflows cannot access secrets.

This PR fixes the issue by sending the `token` directly from the caller workflow.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
