### PR TITLE
Add initial support to init zinc client

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ Alternative to using Elasticsearch, you can also start a single node OpenSearch 
 docker run --name opensearch --rm -d -p 9200:9200 -e http.port=9200 -e discovery.type=single-node -e http.max_content_length=10MB -e http.cors.enabled=true -e http.cors.allow-origin=\* -e http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization -e http.cors.allow-credentials=true --net=reactivesearch opensearchproject/opensearch:1.3.2
 ```
 
-3. Start ReactiveSearch locally
+3. Start Zinc locally
+
+```sh
+mkdir data
+docker run -v /full/path/of/data:/data -e ZINC_DATA_PATH="/data" -p 4080:4080 \
+    -e ZINC_FIRST_ADMIN_USER=appbase -e ZINC_FIRST_ADMIN_PASSWORD=zincf0rappbase \
+    --name zinc public.ecr.aws/zinclabs/zinc:latest
+```
+
+4. Start ReactiveSearch locally
 
 ```sh
 docker build -t reactivesearch . && docker run --rm --name reactivesearch -p 8000:8000 --net=reactivesearch --env-file=config/docker.env reactivesearch

--- a/config/manual.env
+++ b/config/manual.env
@@ -1,5 +1,5 @@
 ES_CLUSTER_URL=http://127.0.0.1:9200
-ZINC_CLUSTER_URL=http://admin:Complexpass#123@localhost:4080
+ZINC_CLUSTER_URL=http://appbase:zincf0rappbase@localhost:4080
 
 USERNAME=foo
 PASSWORD=bar

--- a/config/manual.env
+++ b/config/manual.env
@@ -1,4 +1,5 @@
 ES_CLUSTER_URL=http://127.0.0.1:9200
+ZINC_CLUSTER_URL=http://admin:Complexpass#123@localhost:4080
 
 USERNAME=foo
 PASSWORD=bar

--- a/main.go
+++ b/main.go
@@ -412,6 +412,7 @@ func main() {
 	// ES client instantiation
 	// ES v7 and v6 clients
 	util.NewClient()
+	util.NewZincClient()
 	util.SetDefaultIndexTemplate()
 	util.SetSystemIndexTemplate()
 

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -103,7 +103,7 @@ func (zc *ZincClient) MakeRequest(endpoint string, method string, body []byte, h
 
 	// If authHeader is not empty, set it as basic auth
 	if zc.AuthHeader != "" {
-		(*headers)["Authorization"] = []string{fmt.Sprintf("Basic %s", zc.AuthHeader)}
+		headers.Set("Authorization", fmt.Sprintf("Basic %s", zc.AuthHeader))
 	}
 
 	// Set the headers

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -18,8 +18,8 @@ type ZincClient struct {
 }
 
 var (
-	clientInit *sync.Once
-	zincClient *ZincClient
+	zincClientInit *sync.Once
+	zincClient     *ZincClient
 )
 
 // GetZincData will return the zinc data from the
@@ -81,4 +81,14 @@ func initZincClient() {
 		Password:   password,
 		AuthHeader: authHeader,
 	}
+}
+
+// NewClient instantiates the Zinc Client
+func NewZincClient() {
+	zincClientInit.Do(func() {
+		// Initialize the zinc client
+		initZincClient()
+
+		log.Println("zinc client instantiated")
+	})
 }

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -96,7 +96,9 @@ func (zc *ZincClient) MakeRequest(endpoint string, method string, body []byte, h
 	// Create the request
 	request, requestCreateErr := http.NewRequest(method, urlToHit, bytes.NewReader(body))
 	if requestCreateErr != nil {
-		// TODO: Handle the error
+		// Handle the error
+		log.Warnln(": error while creating request to send Zinc, ", requestCreateErr)
+		return nil, requestCreateErr
 	}
 
 	// If authHeader is not empty, set it as basic auth

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ZincClient struct {
+	URL        string
+	Username   string
+	Password   string
+	AuthHeader string
+}
+
+var (
+	clientInit *sync.Once
+	zincClient *ZincClient
+)
+
+// GetZincData will return the zinc data from the
+// environment.
+//
+// The return will be three strings:
+// - URL
+// - username
+// - password
+func GetZincData() (string, string, string) {
+	zincURL := os.Getenv("ZINC_CLUSTER_URL")
+
+	if zincURL == "" {
+		log.Fatal("Error encountered: ", fmt.Errorf("ES_CLUSTER_URL must be set in the environment variables"))
+	}
+
+	username, password := "", ""
+
+	if strings.Contains(zincURL, "@") {
+		splitIndex := strings.LastIndex(zincURL, "@")
+		protocolWithCredentials := strings.Split(zincURL[0:splitIndex], "://")
+		credentials := protocolWithCredentials[1]
+		protocol := protocolWithCredentials[0]
+		host := zincURL[splitIndex+1:]
+
+		credentialSeparator := strings.Index(credentials, ":")
+		username = credentials[0:credentialSeparator]
+		password = credentials[credentialSeparator+1:]
+
+		zincURL = fmt.Sprintf("%s://%s", protocol, host)
+
+	}
+	return zincURL, username, password
+}

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strings"
@@ -52,4 +53,32 @@ func GetZincData() (string, string, string) {
 
 	}
 	return zincURL, username, password
+}
+
+// GetZincClient will return the zinc client and only
+// init it once.
+func GetZincClient() *ZincClient {
+	// initialize the client if not present
+	if zincClient == nil {
+		initZincClient()
+	}
+	return zincClient
+}
+
+// initZincClient will initiate the zinc client
+// by extracting the details from the env file.
+func initZincClient() {
+	zincURL, username, password := GetZincData()
+	authHeader := ""
+
+	if username != "" && password != "" {
+		authHeader = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	}
+
+	zincClient = &ZincClient{
+		URL:        zincURL,
+		Username:   username,
+		Password:   password,
+		AuthHeader: authHeader,
+	}
 }

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -90,7 +90,8 @@ func (zc *ZincClient) MakeRequest(endpoint string, method string, body []byte, h
 	urlToHit := fmt.Sprintf("%s/%s", zc.URL, endpoint)
 
 	if headers == nil {
-		headers = new(http.Header)
+		defaultHeader := make(http.Header)
+		headers = &defaultHeader
 	}
 
 	// Create the request

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -81,6 +83,36 @@ func initZincClient() {
 		Password:   password,
 		AuthHeader: authHeader,
 	}
+}
+
+// MakeRequest will allow making a request to zinc index.
+func (zc *ZincClient) MakeRequest(endpoint string, method string, body []byte, headers *http.Header) (*http.Response, error) {
+	urlToHit := fmt.Sprintf("%s/%s", zc.URL, endpoint)
+
+	if headers == nil {
+		headers = new(http.Header)
+	}
+
+	// Create the request
+	request, requestCreateErr := http.NewRequest(method, urlToHit, bytes.NewReader(body))
+	if requestCreateErr != nil {
+		// TODO: Handle the error
+	}
+
+	// If authHeader is not empty, set it as basic auth
+	if zc.AuthHeader != "" {
+		(*headers)["Authorization"] = []string{fmt.Sprintf("Basic %s", zc.AuthHeader)}
+	}
+
+	// Set the headers
+	for key, value := range *headers {
+		request.Header.Set(key, strings.Join(value, ", "))
+	}
+
+	// Send the request now
+	response, responseErr := HTTPClient().Do(request)
+
+	return response, responseErr
 }
 
 // NewClient instantiates the Zinc Client

--- a/util/zincclient.go
+++ b/util/zincclient.go
@@ -20,7 +20,7 @@ type ZincClient struct {
 }
 
 var (
-	zincClientInit *sync.Once
+	zincClientInit sync.Once
 	zincClient     *ZincClient
 )
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds initial support to initiate a zinc client on startup and use it through the whole codebase.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
#### Infra dependencies

- [x] Add support for Zinc in the packer images | Enable the service with Packer
- [ ] Add support for Zinc in all Docker compose files in the [reactivesearch-api-docker](https://github.com/appbaseio/reactivesearch-api-docker) repo