### PR TITLE
Fix issue of `value` required for histogram aggregations in range query

### DIFF
--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -759,7 +759,7 @@ func mergeMaps(x map[string]interface{}, y map[string]interface{}) map[string]in
 }
 
 func getValidInterval(interval *int, rangeValue RangeValue) int {
-	normalizedInterval := 0
+	normalizedInterval := 1
 	if interval != nil {
 		normalizedInterval = *interval
 	}
@@ -777,7 +777,7 @@ func getValidInterval(interval *int, rangeValue RangeValue) int {
 	if min == 0 {
 		min = 1
 	}
-	if normalizedInterval == 0 {
+	if normalizedInterval == 1 {
 		return int(min)
 	} else if normalizedInterval < int(min) {
 		return int(min)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

Till now, getting histogram aggregations failed if the `value` was not being passed even though ES can handle histograms without the `value` field.

This PR fixes that issue by adding fixes to the logic. This fix is just for ES.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
