### PR TITLE
Add support for `deepPagination` for Elasticsearch

### DIFF
--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -331,7 +331,7 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 	normalizedFields := NormalizedDataFields(query.DataField, query.FieldWeights)
 
 	// Only apply sort on search queries
-	if query.SortBy != nil && query.Type == Search {
+	if (query.SortBy != nil || query.SortField != nil) && query.Type == Search {
 		// If both sortField and dataFields are not present
 		// then raise an error.
 		if len(normalizedFields) < 1 && query.SortField == nil {
@@ -344,6 +344,12 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 		if query.SortField == nil {
 			dataField := normalizedFields[0].Field
 			query.SortField = &dataField
+		}
+
+		// If sortBy is nil, set it to Desc
+		if query.SortBy == nil {
+			defaultSortBy := Desc
+			query.SortBy = &defaultSortBy
 		}
 
 		queryWithOptions["sort"] = []map[string]interface{}{

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -332,13 +332,23 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 
 	// Only apply sort on search queries
 	if query.SortBy != nil && query.Type == Search {
-		if len(normalizedFields) < 1 {
-			return nil, errors.New("field 'dataField' must be present to apply 'sortBy' property")
+		// If both sortField and dataFields are not present
+		// then raise an error.
+		if len(normalizedFields) < 1 && query.SortField == nil {
+			return nil, errors.New("field 'dataField' or `sortField` must be present to apply 'sortBy' property")
 		}
-		dataField := normalizedFields[0].Field
+
+		// sortField get's priority
+		// if not present and normalized field is present
+		// then it is assigned.
+		if query.SortField == nil {
+			dataField := normalizedFields[0].Field
+			query.SortField = &dataField
+		}
+
 		queryWithOptions["sort"] = []map[string]interface{}{
 			{
-				dataField: map[string]interface{}{
+				*query.SortField: map[string]interface{}{
 					"order": *query.SortBy,
 				},
 			},

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -100,6 +100,29 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 			finalQuery := queryOptions
 			finalQuery["query"] = translatedQuery
 
+			// Handle DeepPagination
+			// NOTE: Following code should be before `from` is added to the final
+			// query because deepPagination might modify the from value.
+			if query.DeepPagination == nil {
+				defaultDeepPagination := false
+				query.DeepPagination = &defaultDeepPagination
+			}
+
+			// If deep pagination is enabled, set it to search_after
+			// since this translation is happening for ES.
+			if *query.DeepPagination &&
+				query.DeepPaginationConfig != nil &&
+				query.DeepPaginationConfig.Cursor != nil &&
+				*query.DeepPaginationConfig.Cursor != "" {
+				// Set the from value of the request to 0
+				fromForSearchAfter := 0
+				query.From = &fromForSearchAfter
+
+				// Add the search_after field.
+				searchAfterValue := []string{*query.DeepPaginationConfig.Cursor}
+				finalQuery["search_after"] = searchAfterValue
+			}
+
 			// Apply query options
 			buildQueryOptions, err := query.buildQueryOptions()
 			if err != nil {

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -372,6 +372,11 @@ func (b Backend) JSONSchemaType() *jsonschema.Type {
 	}
 }
 
+// DeepPaginationConfig Struct
+type DeepPaginationConfig struct {
+	Cursor *string `json:"cursor,omitempty"`
+}
+
 // Query represents the query object
 type Query struct {
 	ID                          *string                     `json:"id,omitempty"` // component id
@@ -434,6 +439,8 @@ type Query struct {
 	FeaturedSuggestionsConfig   *FeaturedSuggestionsOptions `json:"featuredSuggestionsConfig,omitempty"`
 	EnableIndexSuggestions      *bool                       `json:"enableIndexSuggestions,omitempty"`
 	IndexSuggestionsConfig      *IndexSuggestionsOptions    `json:"indexSuggestionsConfig,omitempty"`
+	DeepPagination              *bool                       `json:"deepPagination,omitempty"`
+	DeepPaginationConfig        *DeepPaginationConfig       `json:"deepPaginationConfig,omitempty"`
 }
 
 type DataField struct {

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -374,6 +374,11 @@ func (b Backend) JSONSchemaType() *jsonschema.Type {
 
 // DeepPaginationConfig Struct
 type DeepPaginationConfig struct {
+	// The `cursor` value will map according to the
+	// backend.
+	//
+	// - ES: `search_after` ([$cursor])
+	// - Solr: `cursorMark` $cursor
 	Cursor *string `json:"cursor,omitempty"`
 }
 

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -397,6 +397,7 @@ type Query struct {
 	Size                        *int                        `json:"size,omitempty"`
 	AggregationSize             *int                        `json:"aggregationSize,omitempty"`
 	SortBy                      *SortBy                     `json:"sortBy,omitempty"`
+	SortField                   *string                     `json:"sortField,omitempty"`
 	Value                       *interface{}                `json:"value,omitempty"` // either string or Array of string
 	AggregationField            *string                     `json:"aggregationField,omitempty"`
 	After                       *map[string]interface{}     `json:"after,omitempty"`


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?
As of now, only max. 10k results were fetch-able through RS API. This was a restriction provided by ES (and Solr as well). This PR adds support for a few new fields in order to use deepPagination to get all the results for a particular search query.

Following new fields were added in RSQuery:

- `sortField`: This field specifies the field on which sort should be applied. By default is set to the `dataField` value (in case of string) or the first element in the dataField interface (in case of array or map).
- `deepPagination`: This field indicates whether or not deepPagination should be used. It is of type `bool`. By default set to `false`.
- `deepPaginationConfig`: This is a struct that accepts config values for `deepPagination`.
- `deepPaginationConfig.Cursor`: This value is a special parameter required to support deep pagination.

### Note about `cursor`

In case of `ES`, it maps to `search_after`:

```
search_after: [$cursor]
```

In case of Solr, it maps to `cursorMark`: `cursorMark=$cursor`.

### Things to keep in mind before using the functionality.

#### Using with Elasticsearch

The `search_after` value should be the value of the last items `sort` field. This means the first search request (to get 10k results) should have the `sortField` or `sortBy` added.

The `sort` value of the last document can be an array, in which case, the first element should be used.

#### Using with Solr:

> [This PR adds support for above in Solr](https://github.com/appbaseio-confidential/arc-noss/pull/377).

Using the functionality with Solr is different in a few ways:

- RSAPI will now return `nextCursorMark` in the root of Solr so that it can be passed on in subsequent `deepPagination` requests.
- the `cursor` value should be the `nextCursorMark` returned in the root of the Solr response from RS API.

## If this PR affects any API reference documentation, please share the updated endpoint references

Will update once the PR is merged.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
