### PR TITLE
Add endpoint property support for Elasticsearch

### DIFF
--- a/plugins/querytranslate/context.go
+++ b/plugins/querytranslate/context.go
@@ -12,6 +12,8 @@ type contextKey string
 // CtxKey is a key against which api request will get stored in the context.
 const ctxKey = contextKey("request")
 
+const independentReqCtxKey = contextKey("independent-request")
+
 // NewContext returns a new context with the given request body.
 func NewContext(ctx context.Context, rsQuery RSQuery) context.Context {
 	return context.WithValue(ctx, ctxKey, rsQuery)
@@ -26,6 +28,26 @@ func FromContext(ctx context.Context) (*RSQuery, error) {
 	reqQuery, ok := ctxRequest.(RSQuery)
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "RSQuery")
+	}
+	return &reqQuery, nil
+}
+
+// NewIndependentRequestContext returns a new context with the
+// given independent request body.
+func NewIndependentRequestContext(ctx context.Context, rsQuery RSQuery) context.Context {
+	return context.WithValue(ctx, independentReqCtxKey, rsQuery)
+}
+
+// FromIndependentRequestContext retrieves the rs ap request stored
+// against the querytranslate.ctxKey from the context.
+func FromIndependentRequestContext(ctx context.Context) (*RSQuery, error) {
+	ctxRequest := ctx.Value(independentReqCtxKey)
+	if ctxRequest == nil {
+		return nil, errors.NewNotFoundInContextError("Independent RSQuery")
+	}
+	reqQuery, ok := ctxRequest.(RSQuery)
+	if !ok {
+		return nil, errors.NewInvalidCastError("ctxRequest", "Independent RSQuery")
 	}
 	return &reqQuery, nil
 }

--- a/plugins/querytranslate/context.go
+++ b/plugins/querytranslate/context.go
@@ -38,7 +38,7 @@ func NewIndependentRequestContext(ctx context.Context, independentRequests []map
 	return context.WithValue(ctx, independentReqCtxKey, independentRequests)
 }
 
-// FromIndependentRequestContext retrieves the rs ap request stored
+// FromIndependentRequestContext retrieves the rs api request stored
 // against the querytranslate.ctxKey from the context.
 func FromIndependentRequestContext(ctx context.Context) (*[]map[string]interface{}, error) {
 	ctxRequest := ctx.Value(independentReqCtxKey)

--- a/plugins/querytranslate/context.go
+++ b/plugins/querytranslate/context.go
@@ -34,18 +34,18 @@ func FromContext(ctx context.Context) (*RSQuery, error) {
 
 // NewIndependentRequestContext returns a new context with the
 // given independent request body.
-func NewIndependentRequestContext(ctx context.Context, rsQuery RSQuery) context.Context {
-	return context.WithValue(ctx, independentReqCtxKey, rsQuery)
+func NewIndependentRequestContext(ctx context.Context, independentRequests []map[string]interface{}) context.Context {
+	return context.WithValue(ctx, independentReqCtxKey, independentRequests)
 }
 
 // FromIndependentRequestContext retrieves the rs ap request stored
 // against the querytranslate.ctxKey from the context.
-func FromIndependentRequestContext(ctx context.Context) (*RSQuery, error) {
+func FromIndependentRequestContext(ctx context.Context) (*[]map[string]interface{}, error) {
 	ctxRequest := ctx.Value(independentReqCtxKey)
 	if ctxRequest == nil {
 		return nil, errors.NewNotFoundInContextError("Independent RSQuery")
 	}
-	reqQuery, ok := ctxRequest.(RSQuery)
+	reqQuery, ok := ctxRequest.([]map[string]interface{})
 	if !ok {
 		return nil, errors.NewInvalidCastError("ctxRequest", "Independent RSQuery")
 	}

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -264,7 +264,7 @@ func (r *QueryTranslate) validate() http.HandlerFunc {
 
 		// Extract some request details that might be required later
 		vars := mux.Vars(req)
-		defaultURL := fmt.Sprint(util.GetESURL(), "/", vars["index"], "/_msearch")
+		defaultURL := fmt.Sprint(util.GetESURL(), "/", vars["index"], "/_search")
 		methodUsed := req.Method
 
 		validateMapToShow := make([]map[string]interface{}, 0)

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -108,6 +108,16 @@ func (r *QueryTranslate) validate() http.HandlerFunc {
 			util.WriteBackError(w, "Can't read request body", http.StatusBadRequest)
 			return
 		}
+
+		independentReqBody, independentErr := FromIndependentRequestContext(req.Context())
+		if independentErr != nil {
+			log.Errorln(logTag, ": ", err)
+			util.WriteBackError(w, "Can't read independent requests built", http.StatusBadRequest)
+			return
+		}
+
+		log.Debugln(logTag, ": independent requests: ", *independentReqBody)
+
 		w.Header().Add("Content-Type", "application/x-ndjson")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusOK)

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -71,6 +71,20 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 			return
 		}
 
+		// This is where the independent requests will be done.
+		independentReqBody, independentErr := FromIndependentRequestContext(req.Context())
+		if independentErr != nil {
+			log.Errorln(logTag, ": ", err)
+			util.WriteBackError(w, "Can't read independent requests built", http.StatusBadRequest)
+			return
+		}
+
+		independentResponse := make([][]map[string]interface{}, 0)
+
+		for _, independentReq := range *independentReqBody {
+			// Make the request with the passed details.
+		}
+
 		indices, err := index.FromContext(req.Context())
 		if err != nil {
 			msg := "error getting the index names from context"

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -255,7 +255,8 @@ func (r *QueryTranslate) validate() http.HandlerFunc {
 		// Extract the reqBody into the required format that shows based on ID.
 
 		// Extract some request details that might be required later
-		defaultURL := fmt.Sprint(req.Host, req.URL.Path)
+		vars := mux.Vars(req)
+		defaultURL := fmt.Sprint(util.GetESURL(), "/", vars["index"], "/_msearch")
 		methodUsed := req.Method
 
 		validateMapToShow := make([]map[string]interface{}, 0)

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -210,8 +210,12 @@ func ExecuteIndependentQuery(independentReq map[string]interface{}) ([]byte, *ht
 	bodyToUse, bodyOk := endpointAsMap["body"].(interface{})
 	if !bodyOk {
 		errMsg := fmt.Sprint("error while extracting body from independent request built for: ", requestId)
-		return nil, nil, fmt.Errorf(errMsg)
+		log.Warnln(logTag, ": ", errMsg)
+		// No need to return, instead set the body as empty
+		defaultBody := make([]byte, 0)
+		bodyToUse = defaultBody
 	}
+
 	// Marshal the body
 	bodyInBytes, marshalErr := json.Marshal(bodyToUse)
 	if marshalErr != nil {

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -196,7 +196,7 @@ func ExecuteIndependentQuery(independentReq map[string]interface{}) ([]byte, *ht
 		errMsg := fmt.Sprint("error while extracting headers from independent request built for: ", requestId)
 		return nil, nil, fmt.Errorf(errMsg)
 	}
-	headerToSend := new(http.Header)
+	headerToSend := make(http.Header)
 	for key, value := range headersToUse {
 		valueAsString, valueAsStrOk := value.(string)
 		if !valueAsStrOk {
@@ -224,7 +224,7 @@ func ExecuteIndependentQuery(independentReq map[string]interface{}) ([]byte, *ht
 		return nil, nil, fmt.Errorf(errMsg)
 	}
 
-	respBody, res, reqErr := util.MakeRequestWithHeader(urlToHit, methodToUse, bodyInBytes, *headerToSend)
+	respBody, res, reqErr := util.MakeRequestWithHeader(urlToHit, methodToUse, bodyInBytes, headerToSend)
 	if reqErr != nil {
 		errMsg := fmt.Sprintf("error while sending independent request for ID: `%s` with err: `%v`", requestId, reqErr)
 		log.Errorln(logTag, ": ", errMsg)

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -107,7 +107,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 				return
 			}
 
-			headersToUse, headerOk := endpointAsMap["headers"].(map[string]interface{})
+			headersToUse, headerOk := endpointAsMap["headers"].(map[string]string)
 			if !headerOk {
 				errMsg := fmt.Sprint("error while extracting headers from independent request built for: ", requestId)
 				util.WriteBackError(w, errMsg, http.StatusInternalServerError)
@@ -133,7 +133,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 				return
 			}
 
-			respBody, res, reqErr := util.MakeRequestWithHeader(urlToHit, methodToUse, bodyInBytes, *headerToSend)
+			respBody, _, reqErr := util.MakeRequestWithHeader(urlToHit, methodToUse, bodyInBytes, *headerToSend)
 			if reqErr != nil {
 				errMsg := fmt.Sprint("error while sending independent request for ID: `%s` with err: `%v`", requestId, reqErr)
 				log.Errorln(logTag, ": ", errMsg)

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -225,8 +225,8 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 // buildIndependentRequests will build the requests that have the endpoint
 // property passed and will accordingly generate an array of objects
 // that will be hit one by one during searching.
-func buildIndependentRequests(rsQuery RSQuery) ([][]byte, error) {
-	independentQueryArr := make([][]byte, 0)
+func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error) {
+	independentQueryArr := make([]map[string]interface{}, 0)
 
 	for _, query := range rsQuery.Query {
 		if query.Endpoint == nil {
@@ -258,7 +258,16 @@ func buildIndependentRequests(rsQuery RSQuery) ([][]byte, error) {
 			return independentQueryArr, marshalErr
 		}
 
-		independentQueryArr = append(independentQueryArr, builtQuery)
+		// Unmarshal the built query into a map
+		queryAsMap := make(map[string]interface{})
+
+		unmarshalErr := json.Unmarshal(builtQuery, &queryAsMap)
+		if unmarshalErr != nil {
+			log.Warnln(logTag, ": error while unmarshalling query for hitting independently, ", unmarshalErr)
+			return independentQueryArr, unmarshalErr
+		}
+
+		independentQueryArr = append(independentQueryArr, queryAsMap)
 	}
 
 	return independentQueryArr, nil

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -268,8 +268,14 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 
 			delete(queryAsMap, "endpoint")
 
+			bodyToSend := map[string]interface{}{
+				"query": []map[string]interface{}{
+					queryAsMap,
+				},
+			}
+
 			query.Endpoint.Body = new(interface{})
-			*query.Endpoint.Body = queryAsMap
+			*query.Endpoint.Body = bodyToSend
 
 		}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -263,7 +263,7 @@ func BuildIndependentRequest(query Query, rsQuery RSQuery) (map[string]interface
 
 	// If body is not passed, pass the current body without
 	// the endpoint property.
-	if query.Endpoint.Body == nil {
+	if query.Endpoint.Body == nil && *query.Endpoint.Method == http.MethodPost {
 		// Generate the body without the endpoint part
 		queryAsMap := make(map[string]interface{})
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -288,6 +288,8 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 			return independentQueryArr, unmarshalErr
 		}
 
+		queryAsMap["id"] = *query.ID
+
 		independentQueryArr = append(independentQueryArr, queryAsMap)
 	}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -3,6 +3,7 @@ package querytranslate
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 
 	"github.com/appbaseio/reactivesearch-api/util"
@@ -72,6 +73,20 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 				rsQuery.Query[queryIndex].DataField = normalizedDataFields
 			} else {
 				return "", errors.New("you're using .synonyms suffix fields in the 'dataField' property but 'enableSynonyms' property is set to `false`. We recommend removing these fields from the Search Settings UI / API or set enableSynonyms to true")
+			}
+		}
+
+		// Validate the endpoint property
+		if query.Endpoint != nil {
+			if query.Endpoint.URL == nil || *query.Endpoint.URL == "" {
+				return "", errors.New("`endpoint.url` is a required property when `endpoint` is passed. Remove the `endpoint` property if it's not used.")
+			}
+
+			DEFAULT_METHOD := http.MethodGet
+
+			if query.Endpoint.Method == nil || *query.Endpoint.Method == "" {
+				// Set to default endpoint
+				query.Endpoint.Method = &DEFAULT_METHOD
 			}
 		}
 

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -281,14 +281,16 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 
 		// Unmarshal the built query into a map
 		queryAsMap := make(map[string]interface{})
+		endpointAsMap := make(map[string]interface{})
 
-		unmarshalErr := json.Unmarshal(builtQuery, &queryAsMap)
+		unmarshalErr := json.Unmarshal(builtQuery, &endpointAsMap)
 		if unmarshalErr != nil {
 			log.Warnln(logTag, ": error while unmarshalling query for hitting independently, ", unmarshalErr)
 			return independentQueryArr, unmarshalErr
 		}
 
 		queryAsMap["id"] = *query.ID
+		queryAsMap["endpoint"] = endpointAsMap
 
 		independentQueryArr = append(independentQueryArr, queryAsMap)
 	}

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -235,7 +235,7 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 		}
 
 		DEFAULT_METHOD := http.MethodGet
-		DEFAULT_HEADERS := make(map[string]interface{})
+		DEFAULT_HEADERS := make(map[string]string)
 
 		if query.Endpoint.Method == nil || *query.Endpoint.Method == "" {
 			// Set to default endpoint

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -99,6 +99,13 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 	}
 
 	for _, query := range rsQuery.Query {
+
+		// If the endpoint property is passed, set the query execute as false
+		if query.Endpoint != nil {
+			executeValue := false
+			query.Execute = &executeValue
+		}
+
 		if query.shouldExecuteQuery() {
 			translatedQuery, queryOptions, isGeneratedByValue, translateError := query.getQuery(rsQuery)
 			if translateError != nil {

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -274,6 +274,13 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 				},
 			}
 
+			if rsQuery.Settings != nil {
+				bodyToSend["settings"] = *rsQuery.Settings
+			}
+			if rsQuery.Metadata != nil {
+				bodyToSend["metadata"] = *rsQuery.Metadata
+			}
+
 			query.Endpoint.Body = new(interface{})
 			*query.Endpoint.Body = bodyToSend
 

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -1372,3 +1372,16 @@ func addFieldHighlight(source ESDoc) ESDoc {
 	}
 	return source
 }
+
+// extractIDFromPreference will extract the query ID from the preference
+// string passed.
+//
+// Idea is to split it based on underscore `_` and remove the last element
+// and join it back using underscore `_`
+func extractIDFromPreference(preference string) string {
+	textSplitted := strings.Split(preference, "_")
+
+	textSplitted = textSplitted[:len(textSplitted)-1]
+
+	return strings.Join(textSplitted, "_")
+}

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -382,6 +382,14 @@ type DeepPaginationConfig struct {
 	Cursor *string `json:"cursor,omitempty"`
 }
 
+// Endpoint struct
+type Endpoint struct {
+	URL     *string                 `json:"url,omitempty"`
+	Method  *string                 `json:"method,omitempty"`
+	Headers *map[string]interface{} `json:"headers,omitempty"`
+	Body    *interface{}            `json:"body,omitempty"`
+}
+
 // Query represents the query object
 type Query struct {
 	ID                          *string                     `json:"id,omitempty"` // component id
@@ -447,6 +455,7 @@ type Query struct {
 	IndexSuggestionsConfig      *IndexSuggestionsOptions    `json:"indexSuggestionsConfig,omitempty"`
 	DeepPagination              *bool                       `json:"deepPagination,omitempty"`
 	DeepPaginationConfig        *DeepPaginationConfig       `json:"deepPaginationConfig,omitempty"`
+	Endpoint                    *Endpoint                   `json:"endpoint,omitempty"`
 }
 
 type DataField struct {

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -823,7 +823,8 @@ func (query *Query) shouldExecuteQuery() bool {
 func GetQueryIds(rsQuery RSQuery) []string {
 	var queryIds []string
 	for _, query := range rsQuery.Query {
-		if query.shouldExecuteQuery() {
+		// If endpoint is passed, execute is set as False
+		if query.shouldExecuteQuery() && query.Endpoint == nil {
 			queryIds = append(queryIds, *query.ID)
 		}
 	}

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -384,10 +384,10 @@ type DeepPaginationConfig struct {
 
 // Endpoint struct
 type Endpoint struct {
-	URL     *string                 `json:"url,omitempty"`
-	Method  *string                 `json:"method,omitempty"`
-	Headers *map[string]interface{} `json:"headers,omitempty"`
-	Body    *interface{}            `json:"body,omitempty"`
+	URL     *string            `json:"url,omitempty"`
+	Method  *string            `json:"method,omitempty"`
+	Headers *map[string]string `json:"headers,omitempty"`
+	Body    *interface{}       `json:"body,omitempty"`
 }
 
 // Query represents the query object

--- a/util/util.go
+++ b/util/util.go
@@ -298,6 +298,32 @@ func MakeRequest(url, method string, reqBody []byte) ([]byte, *http.Response, er
 	return body, response, nil
 }
 
+// MakeRequestWithHeader helps in proxing http requests with header support
+func MakeRequestWithHeader(url, method string, reqBody []byte, headers http.Header) ([]byte, *http.Response, error) {
+	request, err := http.NewRequest(method, url, bytes.NewReader(reqBody))
+	if err != nil {
+		log.Errorln("Error while creating request object: ", err)
+		return nil, nil, err
+	}
+
+	for key, value := range headers {
+		request.Header.Set(key, strings.Join(value, ", "))
+	}
+
+	response, err := HTTPClient().Do(request)
+	if err != nil {
+		log.Errorln("Error while making request: ", err)
+		return nil, nil, err
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Errorln("Error while writing response:", err)
+		return nil, nil, err
+	}
+	return body, response, nil
+}
+
 func CheckIfIndexExists(ctx context.Context, indexName string) bool {
 	exists, err := GetClient7().IndexExists(indexName).Do(ctx)
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for the `endpoint` property in Elasticsearch.

Endpoint property can be passed as following:

```json
{
  "query": [
    {
        "id": "test",
        "endpoint": {
            "url": "http://localhost:8000/test-index/_reactivesearch",
            "method": "POST" 
      }
    }
  ]
}
```

This also changes the `/validate` endpoints response body.

### [Reactivesearch Playground link to play with the PR](https://play.reactivesearch.io/embed/mJZr3cnQrFST2yvs6rQR)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
