### PR TITLE
Add support for `includeValues` and `excludeValues` for ES

### DIFF
--- a/plugins/querytranslate/term.go
+++ b/plugins/querytranslate/term.go
@@ -198,6 +198,13 @@ func (query *Query) applyTermsAggsQuery(queryOptions *map[string]interface{}) er
 			"field": dataField,
 		}
 
+		if query.IncludeValues != nil {
+			termsQuery["include"] = *query.IncludeValues
+		}
+		if query.ExcludeValues != nil {
+			termsQuery["exclude"] = *query.ExcludeValues
+		}
+
 		if query.AggregationSize != nil {
 			termsQuery["size"] = query.AggregationSize
 		} else if query.Size != nil {

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -403,6 +403,14 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 		termsQuery := map[string]interface{}{
 			"field": query.CategoryField,
 		}
+
+		if query.IncludeValues != nil {
+			termsQuery["include"] = *query.IncludeValues
+		}
+		if query.ExcludeValues != nil {
+			termsQuery["exclude"] = *query.ExcludeValues
+		}
+
 		// apply size for categories
 		if query.AggregationSize != nil {
 			termsQuery["size"] = query.AggregationSize

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -447,6 +447,8 @@ type Query struct {
 	IndexSuggestionsConfig      *IndexSuggestionsOptions    `json:"indexSuggestionsConfig,omitempty"`
 	DeepPagination              *bool                       `json:"deepPagination,omitempty"`
 	DeepPaginationConfig        *DeepPaginationConfig       `json:"deepPaginationConfig,omitempty"`
+	IncludeValues               *[]string                   `json:"includeValues,omitempty"`
+	ExcludeValues               *[]string                   `json:"excludeValues,omitempty"`
 }
 
 type DataField struct {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for two new fields in RS which will be used in terms aggregations.

Fields are:

1. `includeValues`
2. `excludeValues`

The `includeValues` field will map to `include` nested inside `term` and `excludeValues` will map to `exclude`.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
