### PR TITLE
Add support for `sortField` enhancements

### DIFF
--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -353,7 +353,8 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 			query.SortBy = &defaultSortBy
 		}
 
-		// sortField can be a string, an array of strings or an object
+		// sortField can be a string, an array of strings or an array of objects
+		// and strings
 		// where the key indicates the field to sort on and the value is
 		// one of valid sort types.
 		//

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -331,11 +331,26 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 	normalizedFields := NormalizedDataFields(query.DataField, query.FieldWeights)
 
 	// Only apply sort on search queries
+	//
+	// Following will only be reached if the sortField is passed
+	// or sortBy is passed. This also means that the following criterion
+	// will make sure that sorting on `_score` is done only if neither of
+	// them are passed and in that case we don't pass the sort key at all.
+	//
+	// Above explanation indicates that we can set the sortBy value to `ascending`
+	// if it is not passed without checking whether the sortField is `_score` because
+	// when the sortField is score, it will not go in the following block.
 	if (query.SortBy != nil || query.SortField != nil) && query.Type == Search {
 		// If both sortField and dataFields are not present
 		// then raise an error.
 		if len(normalizedFields) < 1 && query.SortField == nil {
 			return nil, errors.New("field 'dataField' or `sortField` must be present to apply 'sortBy' property")
+		}
+
+		// If sortBy is nil, set it to Desc
+		if query.SortBy == nil {
+			defaultSortBy := Asc
+			query.SortBy = &defaultSortBy
 		}
 
 		// sortField get's priority
@@ -346,11 +361,12 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 			query.SortField = &dataField
 		}
 
-		// If sortBy is nil, set it to Desc
-		if query.SortBy == nil {
-			defaultSortBy := Desc
-			query.SortBy = &defaultSortBy
-		}
+		// sortField can be a string, an array of strings or an object
+		// where the key indicates the field to sort on and the value is
+		// one of valid sort types.
+		//
+		// For string or array of strings, the value of `sortBy` will be
+		// considered.
 
 		queryWithOptions["sort"] = []map[string]interface{}{
 			{

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -378,16 +378,16 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 		}
 
 		// Change the following to support proper formatting of sortField
+		sortValue := make([]map[string]interface{}, 0)
 		for sortField, sortBy := range sortFieldParsed {
-			queryWithOptions["sort"] = []map[string]interface{}{
-				{
-					sortField: map[string]interface{}{
-						"order": sortBy,
-					},
+			sortValue = append(sortValue, map[string]interface{}{
+				sortField: map[string]interface{}{
+					"order": sortBy,
 				},
-			}
+			})
 		}
 
+		queryWithOptions["sort"] = sortValue
 	}
 
 	includeFields := []string{"*"}

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -353,14 +353,6 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 			query.SortBy = &defaultSortBy
 		}
 
-		// sortField get's priority
-		// if not present and normalized field is present
-		// then it is assigned.
-		if query.SortField == nil {
-			dataField := normalizedFields[0].Field
-			query.SortField = &dataField
-		}
-
 		// sortField can be a string, an array of strings or an object
 		// where the key indicates the field to sort on and the value is
 		// one of valid sort types.
@@ -368,6 +360,18 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 		// For string or array of strings, the value of `sortBy` will be
 		// considered.
 
+		sortFieldParsed := make(map[string]int)
+
+		// If not passed, just set the dataField as the sortField with
+		// the value of sortBy.
+		if query.SortField == nil {
+			dataField := normalizedFields[0].Field
+			sortFieldParsed[dataField] = int(*query.SortBy)
+		} else {
+			// TODO: Parse the sortField accordingly.
+		}
+
+		// TODO: Change the following to support proper formatting of sortField
 		queryWithOptions["sort"] = []map[string]interface{}{
 			{
 				*query.SortField: map[string]interface{}{

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -361,25 +361,33 @@ func (query *Query) buildQueryOptions() (map[string]interface{}, error) {
 		// For string or array of strings, the value of `sortBy` will be
 		// considered.
 
-		sortFieldParsed := make(map[string]int)
+		sortFieldParsed := make(map[string]SortBy)
 
 		// If not passed, just set the dataField as the sortField with
 		// the value of sortBy.
 		if query.SortField == nil {
 			dataField := normalizedFields[0].Field
-			sortFieldParsed[dataField] = int(*query.SortBy)
+			sortFieldParsed[dataField] = *query.SortBy
 		} else {
-			// TODO: Parse the sortField accordingly.
+			// Parse the sortField accordingly.
+			var sortFieldParseErr error
+			sortFieldParsed, sortFieldParseErr = ParseSortField(*query, *query.SortBy)
+			if sortFieldParseErr != nil {
+				return nil, sortFieldParseErr
+			}
 		}
 
-		// TODO: Change the following to support proper formatting of sortField
-		queryWithOptions["sort"] = []map[string]interface{}{
-			{
-				*query.SortField: map[string]interface{}{
-					"order": *query.SortBy,
+		// Change the following to support proper formatting of sortField
+		for sortField, sortBy := range sortFieldParsed {
+			queryWithOptions["sort"] = []map[string]interface{}{
+				{
+					sortField: map[string]interface{}{
+						"order": sortBy,
+					},
 				},
-			},
+			}
 		}
+
 	}
 
 	includeFields := []string{"*"}

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -1390,7 +1390,12 @@ func ParseSortField(query Query, defaultSortBy SortBy) (map[string]SortBy, error
 				}
 
 				// If string is okay, add it to map and continue
-				sortFieldParsed[fieldAsString] = defaultSortBy
+				sortByToUse := defaultSortBy
+				if fieldAsString == "_score" {
+					sortByToUse = Desc
+				}
+
+				sortFieldParsed[fieldAsString] = sortByToUse
 
 				continue
 			}
@@ -1440,7 +1445,11 @@ func ParseSortField(query Query, defaultSortBy SortBy) (map[string]SortBy, error
 	}
 
 	// Parse the string and return accordingly.
-	sortFieldParsed[sortFieldAsStr] = defaultSortBy
+	sortByToUse := defaultSortBy
+	if sortFieldAsStr == "_score" {
+		sortByToUse = Desc
+	}
+	sortFieldParsed[sortFieldAsStr] = sortByToUse
 
 	return sortFieldParsed, nil
 }

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -397,7 +397,7 @@ type Query struct {
 	Size                        *int                        `json:"size,omitempty"`
 	AggregationSize             *int                        `json:"aggregationSize,omitempty"`
 	SortBy                      *SortBy                     `json:"sortBy,omitempty"`
-	SortField                   *string                     `json:"sortField,omitempty"`
+	SortField                   *interface{}                `json:"sortField,omitempty"`
 	Value                       *interface{}                `json:"value,omitempty"` // either string or Array of string
 	AggregationField            *string                     `json:"aggregationField,omitempty"`
 	After                       *map[string]interface{}     `json:"after,omitempty"`
@@ -1364,4 +1364,70 @@ func addFieldHighlight(source ESDoc) ESDoc {
 		}
 	}
 	return source
+}
+
+// ParseSortField will parse the sortField based on the values
+// passed.
+func ParseSortField(query Query, defaultSortBy SortBy) (map[string]SortBy, error) {
+	sortFieldParsed := make(map[string]SortBy)
+
+	// Parse as array of interface
+	sortFieldAsArr, asArrOk := (*query.SortField).([]interface{})
+	if asArrOk {
+		// Parse the array and return detail accordingly
+		// The value can be both a map  as well as a string.
+
+		for sortFieldIndex, sortFieldEach := range sortFieldAsArr {
+			// Try to parse it as an object
+			fieldEachAsMap, asMapOk := sortFieldEach.(map[string]interface{})
+			if !asMapOk {
+				// Try to parse as string.
+				fieldAsString, asStrOk := sortFieldEach.(string)
+
+				// If it's not a string either, invalid type is passed.
+				if !asStrOk {
+					return sortFieldParsed, fmt.Errorf("invalid type passed in sortField array at index: %d", sortFieldIndex)
+				}
+
+				// If string is okay, add it to map and continue
+				sortFieldParsed[fieldAsString] = defaultSortBy
+
+				continue
+			}
+
+			// If passed as map, parse it properly.
+			// Make sure only one key is parsed from the index.
+			parseCount := 0
+
+			for key, value := range fieldEachAsMap {
+				if parseCount > 1 {
+					break
+				}
+
+				// Parse the value as sortBy, if fails then raise an error.
+				valueAsSortBy, valueAsSortOk := value.(SortBy)
+				if !valueAsSortOk {
+					return sortFieldParsed, fmt.Errorf("invalid sort value passed for index `%d` and key: `%s`", sortFieldIndex, key)
+				}
+
+				// If value is okay, add it to map.
+				sortFieldParsed[key] = valueAsSortBy
+				parseCount += 1
+			}
+		}
+
+		// Return the parsed map
+		return sortFieldParsed, nil
+	}
+
+	// Parse as string
+	sortFieldAsStr, asStrOk := (*query.SortField).(string)
+	if !asStrOk {
+		return sortFieldParsed, fmt.Errorf("invalid value passed for `sortField`, only array and string are accepted!")
+	}
+
+	// Parse the string and return accordingly.
+	sortFieldParsed[sortFieldAsStr] = defaultSortBy
+
+	return sortFieldParsed, nil
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support to accept various types of values in the `sortField` value in the query.

Moreover, the `sortBy` field is set to `asc` by default and `desc` (when the field is `_score`).

The `sortField` value will be set to the dataField if the `sortBy` value is passed and `sortField` is not passed.

`sortField` now supports three types of values:

1. a string. `sortField = "some data field"`
2. an array of strings: `sortField = ["dF1", "df2"]`
3. combined type:

Example of combined type is:

```json
{
  "sortField": [
      "someDataField" // sortBy will be set to either sortBy value (if passed) else default value (`asc`)
      { "someOtherField": "asc" },
      { "someThirdField": "desc" }
  ]
}
```

[This playground can be used to play around with this feature](https://play.reactivesearch.io/embed/I0UNitzUDGXCYuXD7hvo)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
