### PR TITLE
Add support for a `--version` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	memprofile         bool
 	enableTelemetry    string
 	disableHealthCheck bool
+	showVersion        bool
 	// Version Reactivesearch version set during build
 	Version string
 	// PlanRefreshInterval can be used to define the custom interval to refresh the plan
@@ -119,6 +120,7 @@ func init() {
 	flag.BoolVar(&listPlugins, "plugins", false, "List currently registered plugins")
 	flag.StringVar(&address, "addr", "0.0.0.0", "Address to serve on")
 	flag.BoolVar(&disableHealthCheck, "disable-health-check", false, "Set as `true` to disable health check")
+	flag.BoolVar(&showVersion, "version", false, "show the version of ReactiveSearch")
 	// env port for deployments like heroku where port is dynamically assigned
 	envPort := os.Getenv("PORT")
 	defaultPort := 8000
@@ -180,6 +182,15 @@ func init() {
 }
 
 func main() {
+	// If showVersion is passed, show the version and do
+	// nothing.
+	util.Version = Version
+
+	if showVersion {
+		log.Info("ReactiveSearch ", util.Version)
+		return
+	}
+
 	// add cpu profilling
 	if cpuprofile {
 		defer profile.Start().Stop()
@@ -284,7 +295,6 @@ func main() {
 	util.HostedBilling = HostedBilling
 	util.ClusterBilling = ClusterBilling
 	util.Opensource = Opensource
-	util.Version = Version
 
 	var licenseKey string
 	// check for offline license key

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func init() {
 	flag.StringVar(&address, "addr", "0.0.0.0", "Address to serve on")
 	flag.BoolVar(&disableHealthCheck, "disable-health-check", false, "Set as `true` to disable health check")
 	flag.BoolVar(&showVersion, "version", false, "show the version of ReactiveSearch")
+
 	// env port for deployments like heroku where port is dynamically assigned
 	envPort := os.Getenv("PORT")
 	defaultPort := 8000
@@ -129,13 +130,24 @@ func init() {
 		defaultPort = portValue
 	}
 
-	fmt.Println("=> port used", defaultPort)
 	flag.IntVar(&port, "port", defaultPort, "Port number")
 	flag.StringVar(&pluginDir, "pluginDir", "build/plugins", "Directory containing the compiled plugins")
 	flag.BoolVar(&https, "https", false, "Starts a https server instead of a http server if true")
 	flag.BoolVar(&cpuprofile, "cpuprofile", false, "write cpu profile to `file`")
 	flag.BoolVar(&memprofile, "memprofile", false, "write mem profile to `file`")
 	flag.Parse()
+
+	// If showVersion is passed, show the version and do
+	// nothing.
+	util.Version = Version
+
+	if showVersion {
+		fmt.Println(fmt.Sprintf("ReactiveSearch v%s", util.Version))
+		os.Exit(0)
+	}
+
+	fmt.Println("=> port used", defaultPort)
+
 	// Set telemetry based on the user input
 	// Runtime flag gets the highest priority
 	telemetryEnvVar := os.Getenv("ENABLE_TELEMETRY")
@@ -182,15 +194,6 @@ func init() {
 }
 
 func main() {
-	// If showVersion is passed, show the version and do
-	// nothing.
-	util.Version = Version
-
-	if showVersion {
-		log.Info("ReactiveSearch ", util.Version)
-		return
-	}
-
 	// add cpu profilling
 	if cpuprofile {
 		defer profile.Start().Stop()


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for a `--version` flag that prints out the current built version of the binary.

This can be tested using the following command (after a build is done):

```shell
./build/reactivesearch --version
```

Above will print the version in the following format:

```shell
ReactiveSearch v$VERSION_NUMBER
```

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
