### PR TITLE
feat: add support for enabledEndpointSuggestions

### DIFF
--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -374,15 +374,24 @@ func TransformESResponse(response []byte, rsAPIRequest *RSQuery) ([]byte, error)
 
 	mockedRSResponse, _ := json.Marshal(ES_MOCKED_RESPONSE)
 	for _, query := range rsAPIRequest.Query {
-		if query.Type == Suggestion &&
-			query.EnableIndexSuggestions != nil &&
-			!*query.EnableIndexSuggestions {
-			// mock empty response for suggestions when index suggestions are disabled
-			rsResponseMocked, err := jsonparser.Set(rsResponse, mockedRSResponse, *query.ID)
-			rsResponse = rsResponseMocked
-			if err != nil {
-				log.Errorln(logTag, ":", err)
-				return nil, errors.New("error updating response :" + err.Error())
+		if query.Type == Suggestion {
+			// mock empty response for suggestions when index/endpoint suggestions are disabled
+			isSuggestionDisabled := false
+			if query.EnableIndexSuggestions != nil &&
+				!*query.EnableIndexSuggestions {
+				isSuggestionDisabled = true
+			}
+			if query.EnableEndpointSuggestions != nil &&
+				!*query.EnableEndpointSuggestions {
+				isSuggestionDisabled = true
+			}
+			if isSuggestionDisabled {
+				rsResponseMocked, err := jsonparser.Set(rsResponse, mockedRSResponse, *query.ID)
+				rsResponse = rsResponseMocked
+				if err != nil {
+					log.Errorln(logTag, ":", err)
+					return nil, errors.New("error updating response :" + err.Error())
+				}
 			}
 		}
 	}

--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -99,8 +99,10 @@ func translateQuery(rsQuery RSQuery, userIP string) (string, error) {
 
 		// If the endpoint property is passed, set the query execute as false
 		if query.Endpoint != nil {
-			executeValue := false
-			query.Execute = &executeValue
+			if query.EnableEndpointSuggestions == nil || *query.EnableEndpointSuggestions {
+				executeValue := false
+				query.Execute = &executeValue
+			}
 		}
 
 		if query.shouldExecuteQuery() {
@@ -230,7 +232,10 @@ func buildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 	independentQueryArr := make([]map[string]interface{}, 0)
 
 	for _, query := range rsQuery.Query {
+
 		if query.Endpoint == nil {
+			continue
+		} else if query.EnableEndpointSuggestions != nil && !*query.EnableEndpointSuggestions {
 			continue
 		}
 

--- a/plugins/querytranslate/util.go
+++ b/plugins/querytranslate/util.go
@@ -98,6 +98,7 @@ const (
 	Recent
 	Promoted
 	Featured
+	EndpointSuggestion
 )
 
 // String is the implementation of Stringer interface that returns the string representation of SuggestionType type.
@@ -108,6 +109,7 @@ func (o SuggestionType) String() string {
 		"recent",
 		"promoted",
 		"featured",
+		"endpoint",
 	}[o]
 }
 
@@ -129,6 +131,8 @@ func (o *SuggestionType) UnmarshalJSON(bytes []byte) error {
 		*o = Promoted
 	case Featured.String():
 		*o = Featured
+	case EndpointSuggestion.String():
+		*o = EndpointSuggestion
 	default:
 		return fmt.Errorf("invalid suggestion type encountered: %v", suggestionType)
 	}
@@ -149,6 +153,8 @@ func (o SuggestionType) MarshalJSON() ([]byte, error) {
 		suggestionType = Promoted.String()
 	case Featured:
 		suggestionType = Featured.String()
+	case EndpointSuggestion:
+		suggestionType = EndpointSuggestion.String()
 	default:
 		return nil, fmt.Errorf("invalid suggestion type encountered: %v", o)
 	}
@@ -498,6 +504,7 @@ type Query struct {
 	EnableFeaturedSuggestions   *bool                       `json:"enableFeaturedSuggestions,omitempty" jsonschema:"title=enableFeaturedSuggestions,description=whether or not to enable featured suggestions" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
 	FeaturedSuggestionsConfig   *FeaturedSuggestionsOptions `json:"featuredSuggestionsConfig,omitempty" jsonschema:"title=featuredSuggestionsConfig,description=additional options to specify for featured suggestions" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
 	EnableIndexSuggestions      *bool                       `json:"enableIndexSuggestions,omitempty" jsonschema:"title=enableIndexSuggestions,description=whether or not to enable index suggestions" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
+	EnableEndpointSuggestions   *bool                       `json:"enableEndpointSuggestions,omitempty" jsonschema:"title=enableEndpointSuggestions,description=whether or not to enable endpoint suggestions" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
 	IndexSuggestionsConfig      *IndexSuggestionsOptions    `json:"indexSuggestionsConfig,omitempty" jsonschema:"title=indexSuggestionsConfig,description=additional options to specify for index suggestions" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
 	DeepPagination              *bool                       `json:"deepPagination,omitempty" jsonschema:"title=deepPagination,description=whether or not the enable deep pagination of results" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
 	DeepPaginationConfig        *DeepPaginationConfig       `json:"deepPaginationConfig,omitempty" jsonschema:"title=deepPaginationConfig,description=additional options for deepPagination for it to work properly" jsonschema_extras:"engine=elasticsearch,engine=solr,engine=opensearch"`
@@ -888,6 +895,12 @@ func (query *Query) shouldExecuteQuery() bool {
 	if query.Type == Suggestion &&
 		query.EnableIndexSuggestions != nil &&
 		!*query.EnableIndexSuggestions {
+		return false
+	}
+	// don't execute query if endpoint suggestions are disabled
+	if query.Type == Suggestion &&
+		query.EnableEndpointSuggestions != nil &&
+		!*query.EnableEndpointSuggestions {
 		return false
 	}
 	if query.Execute != nil {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
- [x]  For suggestions type of query, support `enableEndpointSuggestions` key, will work for all search engines
    
    ⇒ If enable endpoint suggestions is true, endpoint query will be made and response for it will be returned.
    
    ⇒ If enable endpoint suggestions is false, endpoint query will not be made, no response for endpoint suggestions will be returned.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
