### PR TITLE
fix(suggestions): predictive suggestions logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GT=go test
 BUILD_DIR=build
 PLUGIN_FLAGS=--buildmode=plugin
 PLUGIN_BUILD_DIR=$(BUILD_DIR)/plugins
-DEFAULT_VERSION=8.5.1
+DEFAULT_VERSION=8.6.0
 VERSION := $(or $(VERSION),$(DEFAULT_VERSION))
  
 PLUGINS=$(shell ls -l plugins | grep ^d | awk '{ print $$9 }')

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -527,13 +527,6 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 					predictiveSuggestion.Value = matchQuery + " " + highlightPhrase
 					predictiveWordGap = maxPredictedWords - len(strings.Split(highlightPhrase, " "))
 					suffixMatch = true
-					if predictiveWordGap == 0 {
-						if !suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] {
-							suggestionsList = append(suggestionsList, predictiveSuggestion)
-							// update map
-							suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] = true
-						}
-					}
 				}
 			}
 			if prefixEnds >= 0 && predictiveWordGap > 0 {
@@ -562,6 +555,12 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 						// update map
 						suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] = true
 					}
+				}
+			} else {
+				if !suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] {
+					suggestionsList = append(suggestionsList, predictiveSuggestion)
+					// update map
+					suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] = true
 				}
 			}
 		}

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -571,7 +571,12 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 // getHighlightedPhrase takes a candidate phrase (prefix or suffix) of the field value based on the match found with the search query.
 // It returns up to maxTokens length of phrase ignoring for any stopwords in between
 func getHighlightedPhrase(candidateWord string, maxTokens int, config SuggestionsConfig) string {
-	wordsPhrase := strings.Split(removeStopwords(candidateWord, config), " ")
+	var wordsPhrase []string
+	if config.ApplyStopwords != nil && *config.ApplyStopwords {
+		wordsPhrase = strings.Split(removeStopwords(candidateWord, config), " ")
+	} else {
+		wordsPhrase = strings.Split(candidateWord, " ")
+	}
 	if len(wordsPhrase) > maxTokens {
 		return strings.TrimSpace(strings.Join(wordsPhrase[:maxTokens], " "))
 	}

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -346,6 +346,7 @@ func populateDefaultSuggestions(
 			}
 		}
 		// stores the normalized field value to match agains the normalized query value
+		docField.value = strings.Replace(docField.value, `"`, ``, -1)
 		fieldValue := normalizeValue(GetTextFromHTML(docField.value))
 		// TODO: This won't work on query synonyms, need to account for that
 		rankField := FindMatch(fieldValue, config.Value, config)
@@ -497,7 +498,6 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 					suffixStarts = max(suffixStarts, matchIndex+1)
 				}
 			}
-			var matched = false
 			maxPredictedWords := 2
 			if config.MaxPredictedWords != nil {
 				maxPredictedWords = *config.MaxPredictedWords
@@ -505,14 +505,17 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 			// helpful for debugging
 			// fmt.Println("prefix ends: ", prefixEnds)
 			// fmt.Println("suffix starts: ", suffixStarts)
+			predictiveWordGap := maxPredictedWords
+			predictiveSuggestion := suggestion
+			suffixMatch := false
 
 			if suffixStarts > 0 {
 				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[suffixStarts:], " "), max(maxPredictedWords, 1), config)
 				// ignore if highlightPhrase contains any of the query tokens
-				stemmedHighlightPhrase := strings.Join(stemmedTokens(highlightPhrase, language), " ")
+				stemmedHighlightPhrase := stemmedTokens(highlightPhrase, language)
 				ignore := false
 				for _, qToken := range stemmedQvls {
-					if strings.Contains(stemmedHighlightPhrase, qToken) {
+					if util.Contains(stemmedHighlightPhrase, qToken) {
 						ignore = true
 					}
 				}
@@ -520,45 +523,44 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 					// helpful for debugging
 					// fmt.Println("in suffix: highlighted phrase is: ", highlightPhrase)
 					matchQuery := config.Value
-					suggestionPhrase := fmt.Sprintf("%s %s%s%s", matchQuery, tags.PreTags, highlightPhrase, tags.PostTags)
-					suggestionValue := matchQuery + " " + highlightPhrase
-					// transform diacritics chars when comparing for uniqueness of predictive suggestions
-					if !suggestionsMap[CompressAndOrder(suggestionValue, config)] {
-						predictiveSuggestion := suggestion
-						predictiveSuggestion.Label = suggestionPhrase
-						predictiveSuggestion.Value = suggestionValue
-						suggestionsList = append(suggestionsList, predictiveSuggestion)
-						// update map
-						suggestionsMap[CompressAndOrder(suggestionValue, config)] = true
-						matched = true
+					predictiveSuggestion.Label = fmt.Sprintf("%s %s%s%s", matchQuery, tags.PreTags, highlightPhrase, tags.PostTags)
+					predictiveSuggestion.Value = matchQuery + " " + highlightPhrase
+					predictiveWordGap = maxPredictedWords - len(strings.Split(highlightPhrase, " "))
+					suffixMatch = true
+					if predictiveWordGap == 0 {
+						if !suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] {
+							suggestionsList = append(suggestionsList, predictiveSuggestion)
+							// update map
+							suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] = true
+						}
 					}
 				}
 			}
-			if prefixEnds >= 0 && !matched {
-				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[:prefixEnds+1], " "), max(maxPredictedWords, 1), config)
+			if prefixEnds >= 0 && predictiveWordGap > 0 {
+				highlightPhrase := getHighlightedPhrase(strings.Join(fieldValues[:prefixEnds+1], " "), max(predictiveWordGap, 1), config)
 				// ignore if highlightPhrase contains any of the query tokens
-				stemmedHighlightPhrase := strings.Join(stemmedTokens(highlightPhrase, language), " ")
+				stemmedHighlightPhrase := stemmedTokens(highlightPhrase, language)
 				ignore := false
 				for _, qToken := range stemmedQvls {
-					if strings.Contains(stemmedHighlightPhrase, qToken) {
+					if util.Contains(stemmedHighlightPhrase, qToken) {
 						ignore = true
 					}
 				}
 				// helpful for debugging
 				// fmt.Println("in prefix: highlighted phrase is: ", highlightPhrase, ", ignore: ", ignore)
 				if !ignore && len(highlightPhrase) > 0 {
-					matchQuery := config.Value
-					suggestionPhrase := tags.PreTags + highlightPhrase + tags.PostTags + " " + matchQuery
-					suggestionValue := highlightPhrase + " " + matchQuery
+					if suffixMatch {
+						predictiveSuggestion.Label = tags.PreTags + highlightPhrase + tags.PostTags + " " + predictiveSuggestion.Label
+						predictiveSuggestion.Value = highlightPhrase + " " + predictiveSuggestion.Value
+					} else {
+						predictiveSuggestion.Label = tags.PreTags + highlightPhrase + tags.PostTags + " " + config.Value
+						predictiveSuggestion.Value = highlightPhrase + " " + config.Value
+					}
 					// transform diacritics chars when comparing for uniqueness of predictive suggestions
-					if !suggestionsMap[CompressAndOrder(suggestionValue, config)] {
-						predictiveSuggestion := suggestion
-						predictiveSuggestion.Label = suggestionPhrase
-						predictiveSuggestion.Value = suggestionValue
+					if !suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] {
 						suggestionsList = append(suggestionsList, predictiveSuggestion)
 						// update map
-						suggestionsMap[CompressAndOrder(suggestionValue, config)] = true
-						matched = true
+						suggestionsMap[CompressAndOrder(predictiveSuggestion.Value, config)] = true
 					}
 				}
 			}
@@ -570,12 +572,7 @@ func getPredictiveSuggestions(config SuggestionsConfig, suggestions *[]Suggestio
 // getHighlightedPhrase takes a candidate phrase (prefix or suffix) of the field value based on the match found with the search query.
 // It returns up to maxTokens length of phrase ignoring for any stopwords in between
 func getHighlightedPhrase(candidateWord string, maxTokens int, config SuggestionsConfig) string {
-	var wordsPhrase []string
-	if config.ApplyStopwords != nil && *config.ApplyStopwords {
-		wordsPhrase = strings.Split(removeStopwords(candidateWord, config), " ")
-	} else {
-		wordsPhrase = strings.Split(candidateWord, " ")
-	}
+	wordsPhrase := strings.Split(removeStopwords(candidateWord, config), " ")
 	if len(wordsPhrase) > maxTokens {
 		return strings.TrimSpace(strings.Join(wordsPhrase[:maxTokens], " "))
 	}

--- a/plugins/querytranslate/suggestions_test.go
+++ b/plugins/querytranslate/suggestions_test.go
@@ -74,8 +74,8 @@ func TestPredictiveSuggestions(t *testing.T) {
 		}, &suggestions)
 		So(predictiveSuggestions, ShouldResemble, []SuggestionHIT{
 			{
-				Label: "tagore <b class=\"highlight\">hall</b>",
-				Value: "tagore hall",
+				Label: "<b class=\"highlight\">rabindranath</b> tagore <b class=\"highlight\">hall</b>",
+				Value: "rabindranath tagore hall",
 			},
 		})
 	})


### PR DESCRIPTION
#### What does this do / why do we need it?

- Fixes query suggestions parsing logic when a document contains a word surrounded by quotes
- Enhances query suggestions to now include both prefix and suffix words within the `maxPredictedWords` limit.

#### What should your reviewer look out for in this PR?

No obv regression, this piece of code is a little tricky to debug

#### Which issue(s) does this PR fix?

Quality of suggestions

#### If this PR affects any API reference documentation, please share the updated endpoint references

N/A

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
