### PR TITLE
Add support for `valueFields` in indexSuggestionsConfig

### DIFF
--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -457,6 +457,13 @@ func TransformESResponse(response []byte, rsAPIRequest *RSQuery) ([]byte, error)
 								for _, dataField := range normalizedFields {
 									normalizedDataFields = append(normalizedDataFields, dataField.Field)
 								}
+
+								// Parse the valueFields passed in indexSuggestionsConfig
+								var valueFields = []string{}
+								if query.IndexSuggestionsConfig != nil && query.IndexSuggestionsConfig.ValueFields != nil {
+									valueFields = *query.IndexSuggestionsConfig.ValueFields
+								}
+
 								suggestionsConfig := SuggestionsConfig{
 									// Fields to extract suggestions
 									DataFields: normalizedDataFields,
@@ -474,6 +481,7 @@ func TransformESResponse(response []byte, rsAPIRequest *RSQuery) ([]byte, error)
 									HighlightConfig:             query.HighlightConfig,
 									Language:                    query.SearchLanguage,
 									IndexSuggestionsConfig:      query.IndexSuggestionsConfig,
+									ValueFields:                 valueFields,
 								}
 
 								var rawHits []ESDoc

--- a/plugins/querytranslate/suggestions.go
+++ b/plugins/querytranslate/suggestions.go
@@ -124,7 +124,8 @@ type FeaturedSuggestionsOptions struct {
 
 // IndexSuggestionsOptions represents the options to configure index suggestions
 type IndexSuggestionsOptions struct {
-	SectionLabel *string `json:"sectionLabel,omitempty"`
+	SectionLabel *string   `json:"sectionLabel,omitempty"`
+	ValueFields  *[]string `json:"valueFields,omitempty"`
 }
 
 // DocField contains properties of the field and the doc it belongs to


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for a new `valueFields` field nested inside the `indexSuggestionsConfig` field. This field should map to an array of strings and these values are given the most priority while determining the `value` and `label` for index type of suggestions.

### [Playground link to test ES](https://play.reactivesearch.io/embed/pxcC3q8U7DRABowSeqX9)

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
