### PR TITLE
fix: read sourcesXffValue from back to front

### DIFF
--- a/util/iplookup/remoteip.go
+++ b/util/iplookup/remoteip.go
@@ -75,8 +75,8 @@ func FromRequest(r *http.Request) string {
 		ipAddresses := strings.Split(xForwardedFor, ",")
 		if sourcesXffValue != 0 {
 			// if xffSourceValue is invalid then throw error
-			if sourcesXffValue < len(ipAddresses) {
-				address := strings.TrimSpace(ipAddresses[sourcesXffValue-1])
+			if sourcesXffValue <= len(ipAddresses) {
+				address := strings.TrimSpace(ipAddresses[len(ipAddresses)-sourcesXffValue])
 				isPrivate, err := isPrivateAddress(address)
 				if !isPrivate && err == nil {
 					return address


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
To read sources xff value from back as the x-forwarded-for header is always having the closest devices at the end of the list.

https://www.loom.com/share/33050d6846e143ba82e20751f5803ca8

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
