### PR TITLE
Add support for substituting host if only path is specified

### DIFF
--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -85,7 +85,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 			// Make the request with the passed details.
 			requestId := independentReq["id"].(string)
 
-			respBody, _, reqErr := ExecuteIndependentQuery(independentReq, req.Host)
+			respBody, _, reqErr := ExecuteIndependentQuery(independentReq, req.Host, req.TLS != nil)
 
 			if reqErr != nil {
 				log.Warnln(logTag, ": ", reqErr)
@@ -170,7 +170,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 
 // ExecuteIndependentQuery will execute the passed independent query and return
 // the response in bytes, HTTP response and error (if any).
-func ExecuteIndependentQuery(independentReq map[string]interface{}, host string) ([]byte, *http.Response, error) {
+func ExecuteIndependentQuery(independentReq map[string]interface{}, host string, isTLS bool) ([]byte, *http.Response, error) {
 	requestId := independentReq["id"].(string)
 
 	endpointAsMap, endpointAsMapOk := independentReq["endpoint"].(map[string]interface{})
@@ -188,7 +188,11 @@ func ExecuteIndependentQuery(independentReq map[string]interface{}, host string)
 	// If the URL is not complete, append the host to make it complete.
 	if !strings.HasPrefix(urlToHit, "http") && strings.HasPrefix(urlToHit, "/") {
 		// Add the host to the path
-		urlToHit = host + urlToHit
+		scheme := "http"
+		if isTLS {
+			scheme = "https"
+		}
+		urlToHit = fmt.Sprintf("%s://%s%s", scheme, host, urlToHit)
 	}
 
 	methodToUse, methodOk := endpointAsMap["method"].(string)

--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -85,7 +85,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 			// Make the request with the passed details.
 			requestId := independentReq["id"].(string)
 
-			respBody, _, reqErr := ExecuteIndependentQuery(independentReq)
+			respBody, _, reqErr := ExecuteIndependentQuery(independentReq, req.Host)
 
 			if reqErr != nil {
 				log.Warnln(logTag, ": ", reqErr)
@@ -170,7 +170,7 @@ func (r *QueryTranslate) search() http.HandlerFunc {
 
 // ExecuteIndependentQuery will execute the passed independent query and return
 // the response in bytes, HTTP response and error (if any).
-func ExecuteIndependentQuery(independentReq map[string]interface{}) ([]byte, *http.Response, error) {
+func ExecuteIndependentQuery(independentReq map[string]interface{}, host string) ([]byte, *http.Response, error) {
 	requestId := independentReq["id"].(string)
 
 	endpointAsMap, endpointAsMapOk := independentReq["endpoint"].(map[string]interface{})
@@ -183,6 +183,12 @@ func ExecuteIndependentQuery(independentReq map[string]interface{}) ([]byte, *ht
 	if !urlOk {
 		errMsg := fmt.Sprint("error while extracting URL from independent request built for: ", requestId)
 		return nil, nil, fmt.Errorf(errMsg)
+	}
+
+	// If the URL is not complete, append the host to make it complete.
+	if !strings.HasPrefix(urlToHit, "http") && strings.HasPrefix(urlToHit, "/") {
+		// Add the host to the path
+		urlToHit = host + urlToHit
 	}
 
 	methodToUse, methodOk := endpointAsMap["method"].(string)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for substituting host and header automatically if only `path` is specified in the `endpoint.URL`.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
