### PR TITLE
fix: remove dataField empty validation when enableSynonyms is false

### DIFF
--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -72,8 +72,6 @@ func translateQuery(rsQuery RSQuery, userIP string, queryForId *string) (string,
 			if len(normalizedDataFields) > 0 {
 				// Set the updated fields
 				rsQuery.Query[queryIndex].DataField = normalizedDataFields
-			} else {
-				return "", nil, errors.New("you're using .synonyms suffix fields in the 'dataField' property but 'enableSynonyms' property is set to `false`. We recommend removing these fields from the Search Settings UI / API or set enableSynonyms to true")
 			}
 		}
 

--- a/util/iplookup/remoteip.go
+++ b/util/iplookup/remoteip.go
@@ -75,8 +75,8 @@ func FromRequest(r *http.Request) string {
 		ipAddresses := strings.Split(xForwardedFor, ",")
 		if sourcesXffValue != 0 {
 			// if xffSourceValue is invalid then throw error
-			if sourcesXffValue < len(ipAddresses) {
-				address := strings.TrimSpace(ipAddresses[sourcesXffValue-1])
+			if sourcesXffValue <= len(ipAddresses) {
+				address := strings.TrimSpace(ipAddresses[len(ipAddresses)-sourcesXffValue])
 				isPrivate, err := isPrivateAddress(address)
 				if !isPrivate && err == nil {
 					return address


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?
To remove the validation when `dataField` is empty and `enableSynonyms` is set to `false`.

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
