### PR TITLE
Add support for setting default endpoint method as `POST`

### DIFF
--- a/plugins/querytranslate/translate.go
+++ b/plugins/querytranslate/translate.go
@@ -265,7 +265,7 @@ func BuildIndependentRequests(rsQuery RSQuery) ([]map[string]interface{}, error)
 // BuildIndependentRequest will build the independent request based on the passed
 // details and return a map to be used during execution of the request.
 func BuildIndependentRequest(query Query, rsQuery RSQuery) (map[string]interface{}, error) {
-	DEFAULT_METHOD := http.MethodGet
+	DEFAULT_METHOD := http.MethodPost
 	DEFAULT_HEADERS := make(map[string]string)
 
 	if query.Endpoint.Method == nil || *query.Endpoint.Method == "" {


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for changing the `endpoint.method` defaults value to `POST` instead of `GET`.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
