### PR TITLE
Add support to hide password from validation URL

### DIFF
--- a/plugins/querytranslate/handlers.go
+++ b/plugins/querytranslate/handlers.go
@@ -366,7 +366,7 @@ func (r *QueryTranslate) validate() http.HandlerFunc {
 			validateMapToShow = append(validateMapToShow, map[string]interface{}{
 				"id": requestID,
 				"endpoint": map[string]interface{}{
-					"url":     request.URL.String(),
+					"url":     util.CleanPasswordFromURL(request.URL.String()),
 					"method":  methodUsed,
 					"headers": headersPassed,
 					"body":    bodyAsMap,

--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -74,6 +74,6 @@ func CleanPasswordFromURL(URL string) string {
 
 	// If it is an URL, clean it up
 	cleanerRe := regexp.MustCompile(`\/\/(?P<username>.+):.+@`)
-	cleanedVar := cleanerRe.ReplaceAllString(URL, "//${username}:***@")
+	cleanedVar := cleanerRe.ReplaceAllString(URL, "//${username}:********@")
 	return cleanedVar
 }

--- a/util/es_logger.go
+++ b/util/es_logger.go
@@ -57,16 +57,23 @@ func cleanSenstiveData(vars *[]interface{}) {
 			continue
 		}
 
-		// Check if URL
-		isURL, _ := regexp.MatchString(`^https?://(www.)?.+\..+$`, stringedVar)
-		if !isURL {
-			continue
-		}
-
-		// If it is an URL, clean it up
-		cleanerRe := regexp.MustCompile(`\/\/(?P<username>.+):.+@`)
-		cleanedVar := cleanerRe.ReplaceAllString(stringedVar, "//${username}:***@")
+		cleanedVar := CleanPasswordFromURL(stringedVar)
 
 		(*vars)[index] = cleanedVar
 	}
+}
+
+// CleanPasswordFromURL will clean password from the URL if
+// it is present
+func CleanPasswordFromURL(URL string) string {
+	// Check if URL
+	isURL, _ := regexp.MatchString(`^https?://(www.)?.+\..+$`, URL)
+	if !isURL {
+		return URL
+	}
+
+	// If it is an URL, clean it up
+	cleanerRe := regexp.MustCompile(`\/\/(?P<username>.+):.+@`)
+	cleanedVar := cleanerRe.ReplaceAllString(URL, "//${username}:***@")
+	return cleanedVar
 }


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support to remove password from the `endpoint.URL` part of the validation response and replaces it with `***` so that it doesn't get exposed to the end user.

<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
