### PR TITLE
Add support for returning `customer_id` in plan response

### DIFF
--- a/util/billing.go
+++ b/util/billing.go
@@ -20,9 +20,9 @@ const ClusterIDEnvName = "CLUSTER_ID"
 const AppbaseIDEnvName = "APPBASE_ID"
 
 // ACCAPI URL
-//var ACCAPI = "https://accapi.appbase.io/"
+var ACCAPI = "https://accapi.appbase.io/"
 
-var ACCAPI = "http://localhost:3000/"
+// var ACCAPI = "http://localhost:3000/"
 
 var planDetailsHook *func([]byte)
 

--- a/util/billing.go
+++ b/util/billing.go
@@ -20,9 +20,9 @@ const ClusterIDEnvName = "CLUSTER_ID"
 const AppbaseIDEnvName = "APPBASE_ID"
 
 // ACCAPI URL
-var ACCAPI = "https://accapi.appbase.io/"
+//var ACCAPI = "https://accapi.appbase.io/"
 
-// var ACCAPI = "http://localhost:3000/"
+var ACCAPI = "http://localhost:3000/"
 
 var planDetailsHook *func([]byte)
 

--- a/util/billing.go
+++ b/util/billing.go
@@ -124,6 +124,7 @@ type ClusterPlan struct {
 	NumberOfMachines        int64  `json:"number_of_machines"`
 	SubscriptionCanceled    bool   `json:"subscription_canceled"`
 	CreatedAt               int64  `json:"created_at"`
+	CustomerID              string `json:"customer_id"`
 }
 
 // ArcUsageResponse stores the response from ACCAPI
@@ -175,6 +176,7 @@ type ArcInstanceDetails struct {
 	FeaturePipelines        bool                   `json:"feature_pipelines"`
 	ClusterID               string                 `json:"cluster_id"`
 	NumberOfMachines        int64                  `json:"number_of_machines"`
+	CustomerID              string                 `json:"customer_id"`
 }
 
 // SetDefaultTier sets the default tier when billing is disabled


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds support for returning `customer_id` in the `/arc/plan` response.

<!--

### [Loom showing this in action](https://www.loom.com/share/3065ef244a324b00ab17c36af8bd2af7)

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
