### PR TITLE
chore(profile): add profiling support over API

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"path"
@@ -298,6 +299,8 @@ func main() {
 	}
 
 	router := mux.NewRouter().StrictSlash(true)
+
+	router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 
 	mainRouter := router.PathPrefix("").Subrouter()
 


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

#### What does this do / why do we need it?

This PR adds support for profiling over API via the `/debug/pprof` group of endpoints.

Profiling CPU (time taken):

An example of profiling for CPU usage is: `/debug/pprof/profile` (will wait for 30s and return a profile), or
You can directly hit `go tool pprof -http=":8080" http://localhost:8000/debug/pprof/profile` to get a profile UI (top, graph, flamegraph) for time taken.

Profiling Heap:

An example for profiling for heap usage is: `/debug/pprof/heap` (will return a profile for the point in time), or
You can directly hit `go tool pprof -http=":8080" http://localhost:8000/debug/pprof/heap` to get a profile UI (top, graph, flamegraph) of heap usage.


See more details for how to profile over here: https://pkg.go.dev/net/http/pprof

#### What should your reviewer look out for in this PR?

There should be no side effects of this addition.

#### Which issue(s) does this PR fix?

This PR addresses how a production user can profile ReactiveSearch API server at runtime.

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
