### PR TITLE
Add support for disabling diffing and profiling using a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GT=go test
 BUILD_DIR=build
 PLUGIN_FLAGS=--buildmode=plugin
 PLUGIN_BUILD_DIR=$(BUILD_DIR)/plugins
-DEFAULT_VERSION=8.9.2
+DEFAULT_VERSION=8.9.3
 VERSION := $(or $(VERSION),$(DEFAULT_VERSION))
  
 PLUGINS=$(shell ls -l plugins | grep ^d | awk '{ print $$9 }')

--- a/README.md
+++ b/README.md
@@ -106,11 +106,23 @@ Prints the basic information
 #### error (default)
 Only log the errors
 
-### CPU Profile
-Set the `cpuprofile` flag to `true` at runtime to enable CPU profiling. Read this article to know more about the usage https://flaviocopes.com/golang-profiling/.
+#### profiling
 
-### Mem Profile
-Set the `memprofile` flag to `true` at runtime to enable memory profiling.
+Set the `profiling` flag to `true` at runtime to enable net profiling endpoints. Profiling endpoints are exposed at `/debug/pprof` route.
+
+Profiling CPU (time taken):
+
+An example of profiling for CPU usage is: /debug/pprof/profile (will wait for 30s and return a profile), or
+You can directly hit go tool pprof -http=":8080" http://localhost:8000/debug/pprof/profile to get a profile UI (top, graph, flamegraph) for time taken.
+
+Profiling Heap:
+
+An example for profiling for heap usage is: /debug/pprof/heap (will return a profile for the point in time), or
+You can directly hit go tool pprof -http=":8080" http://localhost:8000/debug/pprof/heap to get a profile UI (top, graph, flamegraph) of heap usage.
+
+#### diff-logs
+
+Set the `diff-logs` flag to `false` (defaults to `true`) at runtime to disable the use of log diffing algorithm. For high-throughput use-cases (100 requests/sec or above), the log diffing algorithm consumes signficant CPU usage (about ~2 CPU cores per 100 requests/sec) that can be saved by turning off log diffing.
 
 #### TLS Support
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ var (
 	showVersion        bool
 	createSchema       bool
 	enableProfiling    bool
+	enableDiffing      bool
 	// Version Reactivesearch version set during build
 	Version string
 	// PlanRefreshInterval can be used to define the custom interval to refresh the plan
@@ -144,6 +145,7 @@ func init() {
 	flag.BoolVar(&cpuprofile, "cpuprofile", false, "write cpu profile to `file`")
 	flag.BoolVar(&memprofile, "memprofile", false, "write mem profile to `file`")
 	flag.BoolVar(&enableProfiling, "profiling", false, "enable route for pprof through the API")
+	flag.BoolVar(&enableDiffing, "diff-logs", true, "Store logs by calculating the diff instead of storing the raw body")
 	flag.Parse()
 
 	// If showVersion is passed, show the version and do
@@ -223,6 +225,13 @@ func main() {
 	if memprofile {
 		defer profile.Start(profile.MemProfile, profile.NoShutdownHook).Stop()
 	}
+
+	// Set the enable-diffing value in environments
+	shouldEnableDiffing := "true"
+	if !enableDiffing {
+		shouldEnableDiffing = "false"
+	}
+	os.Setenv("SHOULD_ENABLE_DIFFING", shouldEnableDiffing)
 
 	log.SetReportCaller(true)
 	log.SetFormatter(&log.TextFormatter{

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ var (
 	disableHealthCheck bool
 	showVersion        bool
 	createSchema       bool
+	enableProfiling    bool
 	// Version Reactivesearch version set during build
 	Version string
 	// PlanRefreshInterval can be used to define the custom interval to refresh the plan
@@ -142,6 +143,7 @@ func init() {
 	flag.BoolVar(&https, "https", false, "Starts a https server instead of a http server if true")
 	flag.BoolVar(&cpuprofile, "cpuprofile", false, "write cpu profile to `file`")
 	flag.BoolVar(&memprofile, "memprofile", false, "write mem profile to `file`")
+	flag.BoolVar(&enableProfiling, "profiling", false, "enable route for pprof through the API")
 	flag.Parse()
 
 	// If showVersion is passed, show the version and do
@@ -300,7 +302,10 @@ func main() {
 
 	router := mux.NewRouter().StrictSlash(true)
 
-	router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+	if enableProfiling {
+		log.Debugln(logTag, ": enabling route for profiling since flag is passed as true")
+		router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
+	}
 
 	mainRouter := router.PathPrefix("").Subrouter()
 

--- a/plugins/logs/dao_es7.go
+++ b/plugins/logs/dao_es7.go
@@ -153,6 +153,23 @@ func (es *elasticsearch) getRawLogES7(ctx context.Context, ID string, parseDiffs
 		}
 	}
 
+	var logRecord record
+	unmarshalErr := json.Unmarshal(rawLog, &logRecord)
+	if unmarshalErr != nil {
+		errMsg := fmt.Sprint("error occurred while parsing log to log, ", err)
+		return nil, &LogError{
+			Err:  errors.New(errMsg),
+			Code: http.StatusInternalServerError,
+		}
+	}
+
+	// Check if diffLogs is `false`. If it is, then parseDiffs
+	// flag will be ignored since the logs are stored
+	// raw and need to be returned right away.
+	if !logRecord.DiffLogs {
+		return rawLog, nil
+	}
+
 	// If the user passed a flag to parse the diffs, we need to
 	if parseDiffs {
 		rawLog, err = parseStageDiffs(rawLog)


### PR DESCRIPTION
<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

## What does this do / why do we need it?

This PR adds two new flags to the reactivesearch binary:

1. `profiling` to enable the profiling endpoint, i:e `/debug/pprof`
2. `diff-logs` to enable the diffing algorithm or disable it (by passing `false`).
<!--

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
