### PR TITLE
format: send version event trigger without `v` prefix

### DIFF
--- a/.github/workflows/binary-publish.yml
+++ b/.github/workflows/binary-publish.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get the version from the tag
         id: get-version
-        run: echo "version=v${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
   build-arc:
     name: Build ARC binary


### PR DESCRIPTION
#### What does this do / why do we need it?

Removes the `v` prefix for a version, e.g. version gets set as `8.11.0` instead of `v8.11.0`

#### What should your reviewer look out for in this PR?

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
