### PR TITLE
feat: add RS_SETUP_PROFILE tiers for lean demo deployments (v9.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
-config/
+config/*
+!config/*.example
 *.log
 .idea
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26.4 AS builder
 
-ARG VERSION=9.3.0
+ARG VERSION=9.4.0
 ENV VERSION="${VERSION}"
 
 # Default value

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GC=go build
 
 BUILD_DIR=build
-DEFAULT_VERSION=9.3.0
+DEFAULT_VERSION=9.4.0
 VERSION := $(or $(VERSION),$(DEFAULT_VERSION))
 
 cmd: build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ API keys and users support granular permissions: restrict by **index pattern**, 
 
 Full API reference is available [here](https://docs.reactivesearch.io/docs/search/reactivesearch-api/reference).
 
+## Deploy to Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/appbaseio/reactivesearch-api)
+
+Deploy ReactiveSearch API to [Render](https://render.com) in one click. For a fully free stack, pair it with [Aiven's free OpenSearch](https://aiven.io/free-opensearch) — host search on Aiven and the API on Render's free web service tier.
+
+1. Create a free OpenSearch service on Aiven and copy its connection URI.
+2. Click **Deploy to Render** above and set `ES_CLUSTER_URL` to that URI (basic auth may be embedded in the URL).
+3. After deploy, verify the API is up:
+
+```sh
+curl https://<your-service>.onrender.com -u rs-demo:rs-password
+```
+
+Recommended environment variables (defaults are pre-filled in `render.yaml` where noted):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ES_CLUSTER_URL` | — | Upstream Elasticsearch / OpenSearch URL (required) |
+| `RS_SETUP_PROFILE` | `minimal` | Meta indices to create at startup |
+| `USERNAME` | `rs-demo` | Master user created on first start |
+| `PASSWORD` | `rs-password` | Password for the master user |
+| `PORT` | set by Render | Listen port (Render injects this automatically) |
+
 ## Getting Started
 
 Get up and running in minutes. Four steps to a fully functional search stack with Elasticsearch, search pipelines, analytics and a visual dashboard.

--- a/config/minimal.env.example
+++ b/config/minimal.env.example
@@ -1,0 +1,20 @@
+# Minimal setup profile — creates 4 meta indices (.users, .permissions,
+# .pipelines, .pipeline_vars). Copy to config/minimal.env and set values.
+#
+#   cp config/minimal.env.example config/minimal.env
+
+RS_SETUP_PROFILE=minimal
+
+# Upstream Elasticsearch / OpenSearch (basic auth may be embedded in the URL)
+ES_CLUSTER_URL=https://user:password@your-cluster.example.com:9200
+
+# ReactiveSearch API entry credentials (master user created on first start)
+USERNAME=foo
+PASSWORD=bar
+
+# Optional: load JWT public key from disk instead of .publickey index
+# JWT_RSA_PUBLIC_KEY_LOC=/path/to/jwt_rsa_public.pem
+
+# Recommended for local testing
+ENABLE_TELEMETRY=false
+SHOULD_DISABLE_LOGGING=true

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -8,6 +8,18 @@ Plugins might require certain environment variables to be in order initialize th
 
 **Serverless rollover:** Elasticsearch Serverless rejects conditional index rollover (`max_age`, `max_docs`, `max_size`) with `rollover with conditions is not supported in serverless mode`. On Serverless clusters, ReactiveSearch evaluates those thresholds **client-side** before calling the rollover API without conditions. Rollover runs when any threshold is met (OR semantics), same as on self-managed clusters. After rollover, old backing indices beyond the latest two are deleted as usual.
 
+**Setup profile:** Set `RS_SETUP_PROFILE` to control which meta (system) Elasticsearch indices are created at startup. All profiles use 1 primary shard per index except `full`, which keeps the current per-index defaults. Unset defaults to `full` (backward compatible).
+
+| Profile | Primary shards (fresh install) | Indexes created |
+|---------|-------------------------------|-----------------|
+| `minimal` | 4 | `.users`, `.permissions`, `.pipelines`, `.pipeline_vars` |
+| `standard` | 12 | minimal + `.synonyms`, `.searchrelevancy`, `.logs`, `.pipeline_logs`, `.pipeline_invocations`, `.analytics`, `.user_sessions`, `.analytics_preferences` |
+| `full` | ~35–48 | All meta indexes (current behavior) |
+
+On `minimal` and `standard`, the `.publickey` index is not created — set `JWT_RSA_PUBLIC_KEY_LOC` for JWT auth. Rollover aliases (`.logs`, `.analytics`, pipeline telemetry) may grow to two backing indices each over time.
+
+A local test env for the minimal profile is provided as `config/minimal.env.example`. Copy it to `config/minimal.env` (gitignored), set `ES_CLUSTER_URL`, then start the server with `--env=config/minimal.env`.
+
 | Meta index (Serverless default) | `max_age` (non-production) | `max_age` (production plan) |
 |---------------------------------|----------------------------|-----------------------------|
 | `rs_analytics` | 30 days | 30 days |

--- a/plugins/analytics/analytics.go
+++ b/plugins/analytics/analytics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/plugins"
 	"github.com/appbaseio/reactivesearch-api/util"
 	"github.com/robfig/cron"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -37,7 +38,7 @@ const (
 	indexSettingsRecentSearches   = `{
 		"settings":{
 			%s
-		   "index.number_of_shards": 2,
+		   "index.number_of_shards": %d,
 		   "index.number_of_replicas": %d
 		},
 		"mappings": %s
@@ -89,6 +90,14 @@ func (a *Analytics) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (a *Analytics) InitFunc() error {
+	if !util.IsAnalyticsPluginEnabled() {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		a.session = InitSession(10000, 30)
+		a.timestampSession = InitTimestampSession(10000, 30)
+		a.userSession = InitUserSession(60000, defaultUserSessionDuration*60, nil)
+		return nil
+	}
+
 	// fetch the required env vars
 	analyticsIndex := os.Getenv(envAnalyticsEsIndex)
 	if analyticsIndex == "" {
@@ -152,9 +161,11 @@ func (a *Analytics) InitFunc() error {
 	}
 
 	// Create the recent documents index
-	a.recentDocuments, err = createRecentSearchesIndex(recentDocumentsIndex, indexSettingsRecentSearches)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexRecentDocuments) {
+		a.recentDocuments, err = createRecentSearchesIndex(recentDocumentsIndex, indexSettingsRecentSearches)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create a session to record search ids with a 30s max TTL
@@ -200,34 +211,37 @@ func (a *Analytics) InitFunc() error {
 	SetPreferencesInCache(analyticsPrefs)
 
 	// init cron job
-	cronjob := cron.New()
-	cronjob.AddFunc("@midnight", func() { a.es.rolloverIndexJob(analyticsIndex) })
-	// in addition, run every hour, keeping original midnight job as well
-	cronjob.AddFunc("@hourly", func() { a.es.rolloverIndexJob(analyticsIndex) })
-	cronjob.Start()
+	if util.ShouldCreateMetaIndex(util.MetaIndexAnalytics) {
+		cronjob := cron.New()
+		cronjob.AddFunc("@midnight", func() { a.es.rolloverIndexJob(analyticsIndex) })
+		cronjob.AddFunc("@hourly", func() { a.es.rolloverIndexJob(analyticsIndex) })
+		if util.ClusterBilling == "true" {
+			cronjob.AddFunc("@midnight", a.es.deleteOldMetricBeatIndices)
+		}
+		cronjob.Start()
+	}
 
 	// init a monthly cron job to send analytics report to the admin users
-	analyticsCronJob := cron.New()
-	// Run once a month, midnight, first of month
-	analyticsCronJob.AddFunc("@monthly", a.es.reportAnalyticsToUsers)
-	analyticsCronJob.Start()
+	if util.ShouldCreateMetaIndex(util.MetaIndexAnalyticsInsights) {
+		analyticsCronJob := cron.New()
+		analyticsCronJob.AddFunc("@monthly", a.es.reportAnalyticsToUsers)
+		analyticsCronJob.Start()
+	}
 
 	// Add analytics mapping changes migration script
-	m := MappingsMigration{
-		NewMapping: getAnalyticsMappings(),
-		es:         a.es.(*elasticsearch),
+	if util.ShouldCreateMetaIndex(util.MetaIndexAnalytics) {
+		m := MappingsMigration{
+			NewMapping: getAnalyticsMappings(),
+			es:         a.es.(*elasticsearch),
+		}
+		util.AddMigrationScript(m)
 	}
-	util.AddMigrationScript(m)
-	// Add user session mapping changes to migration script
-	util.AddMigrationScript(UserSessionMappingsMigration{
-		NewMapping: getUserSessionMappings(),
-		es:         a.es.(*elasticsearch),
-		indexName:  userSessionIndex,
-	})
-	clusterBilling := util.ClusterBilling
-
-	if clusterBilling == "true" {
-		cronjob.AddFunc("@midnight", a.es.deleteOldMetricBeatIndices)
+	if util.ShouldCreateMetaIndex(util.MetaIndexUserSessions) {
+		util.AddMigrationScript(UserSessionMappingsMigration{
+			NewMapping: getUserSessionMappings(),
+			es:         a.es.(*elasticsearch),
+			indexName:  userSessionIndex,
+		})
 	}
 	return nil
 }

--- a/plugins/analytics/dao.go
+++ b/plugins/analytics/dao.go
@@ -43,59 +43,82 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 
 	es := &elasticsearch{analyticsAlias, logsIndex, userSessionIndex, insightsIndex, usersIndex, savedSearchesIndex, favoritesIndex, preferencesIndex}
 
-	// Check if alias exists instead of index and create first index if not exists with `${alias}-000001`
-	res, err := util.GetClient7().Aliases().Index("_all").Do(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error while checking if index already exists: %v", err)
-	}
-	indices := res.IndicesByAlias(analyticsAlias)
-	isAnalyticsIndexExist := false
-	if len(indices) > 0 {
-		isAnalyticsIndexExist = true
+	needAnalytics := util.ShouldCreateMetaIndex(util.MetaIndexAnalytics)
+	needUserSessions := util.ShouldCreateMetaIndex(util.MetaIndexUserSessions)
+	needInsights := util.ShouldCreateMetaIndex(util.MetaIndexAnalyticsInsights)
+	needSavedSearches := util.ShouldCreateMetaIndex(util.MetaIndexSavedSearches)
+	needFavorites := util.ShouldCreateMetaIndex(util.MetaIndexFavorites)
+	needPreferences := util.ShouldCreateMetaIndex(util.MetaIndexAnalyticsPreferences)
+
+	isAnalyticsIndexExist := true
+	if needAnalytics {
+		res, err := util.GetClient7().Aliases().Index("_all").Do(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error while checking if index already exists: %v", err)
+		}
+		indices := res.IndicesByAlias(analyticsAlias)
+		isAnalyticsIndexExist = len(indices) > 0
 	}
 
-	// Check if user sessions index exists
-	isUserSessionIndexExist, err1 := util.GetClient7().IndexExists(userSessionIndex).Do(ctx)
-	if err1 != nil {
-		return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
-	}
-	// Check if analytics insights index exists
-	isInsightsIndexExist, err1 := util.GetClient7().IndexExists(insightsIndex).Do(ctx)
-	if err1 != nil {
-		return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+	isUserSessionIndexExist := true
+	if needUserSessions {
+		var err1 error
+		isUserSessionIndexExist, err1 = util.GetClient7().IndexExists(userSessionIndex).Do(ctx)
+		if err1 != nil {
+			return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+		}
 	}
 
-	// Check if saved searches index exists
-	isSavedSearchesIndexExist, err1 := util.GetClient7().IndexExists(savedSearchesIndex).Do(ctx)
-	if err1 != nil {
-		return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+	isInsightsIndexExist := true
+	if needInsights {
+		var err1 error
+		isInsightsIndexExist, err1 = util.GetClient7().IndexExists(insightsIndex).Do(ctx)
+		if err1 != nil {
+			return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+		}
 	}
 
-	// Check if favorites index exists
-	isFavoritesIndexExist, err1 := util.GetClient7().IndexExists(favoritesIndex).Do(ctx)
-	if err1 != nil {
-		return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+	isSavedSearchesIndexExist := true
+	if needSavedSearches {
+		var err1 error
+		isSavedSearchesIndexExist, err1 = util.GetClient7().IndexExists(savedSearchesIndex).Do(ctx)
+		if err1 != nil {
+			return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+		}
 	}
 
-	// Check if preferences index exists
-	isPreferencesIndexExist, prefErr := util.GetClient7().IndexExists(preferencesIndex).Do(ctx)
-	if prefErr != nil {
-		return nil, fmt.Errorf("error while checking if preferences index already exists: %v", prefErr)
+	isFavoritesIndexExist := true
+	if needFavorites {
+		var err1 error
+		isFavoritesIndexExist, err1 = util.GetClient7().IndexExists(favoritesIndex).Do(ctx)
+		if err1 != nil {
+			return nil, fmt.Errorf("error while checking if index already exists: %v", err1)
+		}
 	}
 
-	if isAnalyticsIndexExist && isUserSessionIndexExist && isInsightsIndexExist && isSavedSearchesIndexExist && isFavoritesIndexExist && isPreferencesIndexExist {
-		log.Println(logTag, ": index named", analyticsAlias, "already exists, skipping...")
-		log.Println(logTag, ": index named", userSessionIndex, "already exists, skipping...")
-		log.Println(logTag, ": index named", insightsIndex, "already exists, skipping...")
-		log.Println(logTag, ": index named", savedSearchesIndex, "already exists, skipping...")
-		log.Println(logTag, ": index named", favoritesIndex, "already exists, skipping...")
-		log.Println(logTag, ": index named", preferencesIndex, "already exists, skipping...")
+	isPreferencesIndexExist := true
+	if needPreferences {
+		var prefErr error
+		isPreferencesIndexExist, prefErr = util.GetClient7().IndexExists(preferencesIndex).Do(ctx)
+		if prefErr != nil {
+			return nil, fmt.Errorf("error while checking if preferences index already exists: %v", prefErr)
+		}
+	}
+
+	if (!needAnalytics || isAnalyticsIndexExist) &&
+		(!needUserSessions || isUserSessionIndexExist) &&
+		(!needInsights || isInsightsIndexExist) &&
+		(!needSavedSearches || isSavedSearchesIndexExist) &&
+		(!needFavorites || isFavoritesIndexExist) &&
+		(!needPreferences || isPreferencesIndexExist) {
+		log.Println(logTag, ": analytics meta indices already exist or disabled for profile, skipping creation...")
 		return es, nil
 	}
 
 	replicas := util.GetReplicas()
+	var err error
 	// Analytics index does not exists, create a new one
-	if !isAnalyticsIndexExist {
+	if needAnalytics && !isAnalyticsIndexExist {
 		settings := util.AdaptIndexBody(fmt.Sprintf(analyticsMapping, analyticsAlias, getAnalyticsMappings(), util.HiddenIndexSettings(), replicas))
 		analyticsIndex := analyticsAlias + `-000001`
 		_, err = util.GetClient7().CreateIndex(analyticsIndex).
@@ -145,7 +168,7 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, util.HiddenIndexSettings(), replicas))
 
 	// User session index does not exists, create a new one
-	if !isUserSessionIndexExist {
+	if needUserSessions && !isUserSessionIndexExist {
 		settings := util.AdaptIndexBody(fmt.Sprintf(userSessionMapping, getUserSessionMappings(), util.HiddenIndexSettings(), replicas))
 		_, err = util.GetClient7().CreateIndex(userSessionIndex).Body(settings).Do(ctx)
 		if err != nil {
@@ -155,7 +178,7 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 	}
 
 	// Analytics insights index does not exists, create a new one
-	if !isInsightsIndexExist {
+	if needInsights && !isInsightsIndexExist {
 		_, err = util.GetClient7().CreateIndex(insightsIndex).Body(settings).Do(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error while creating index named %s: %v", insightsIndex, err)
@@ -164,7 +187,7 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 	}
 
 	// Analytics saved searches index does not exists, create a new one
-	if !isSavedSearchesIndexExist {
+	if needSavedSearches && !isSavedSearchesIndexExist {
 		_, err = util.GetClient7().CreateIndex(savedSearchesIndex).Body(settings).Do(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error while creating index named %s: %v", savedSearchesIndex, err)
@@ -173,7 +196,7 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 	}
 
 	// Analytics favorites index does not exists, create a new one
-	if !isFavoritesIndexExist {
+	if needFavorites && !isFavoritesIndexExist {
 		_, err = util.GetClient7().CreateIndex(favoritesIndex).Body(settings).Do(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error while creating index named %s: %v", favoritesIndex, err)
@@ -182,7 +205,7 @@ func initPlugin(analyticsAlias, logsIndex, usersIndex, userSessionIndex, insight
 	}
 
 	// If preferences index doesn't exist, create it.
-	if !isPreferencesIndexExist {
+	if needPreferences && !isPreferencesIndexExist {
 		prefsSettings := util.AdaptIndexBody(fmt.Sprintf(preferencesMapping, util.HiddenIndexSettings(), replicas))
 		_, err = util.GetClient7().CreateIndex(preferencesIndex).Body(prefsSettings).Do(ctx)
 		if err != nil {
@@ -3059,7 +3082,7 @@ func (es *elasticsearch) rolloverIndexJob(alias string) {
 	if shouldRollover {
 		rolloverSvc := util.NewIndicesRolloverService(alias, rolloverConditions).
 			Mappings(mappings)
-		if settings := util.RolloverIndexSettings(2); len(settings) > 0 {
+		if settings := util.RolloverIndexSettings(util.MetaIndexShards(2)); len(settings) > 0 {
 			rolloverSvc = rolloverSvc.Settings(settings)
 		}
 		rolloverService, err := rolloverSvc.Do(ctx)
@@ -3800,7 +3823,7 @@ func createRecentSearchesIndex(indexWithSuffix, indexConfig string) (*recentDocu
 
 	mappings = fmt.Sprintf(mappings, mappingForType)
 
-	settings := util.AdaptIndexBody(fmt.Sprintf(indexConfig, util.HiddenIndexSettings(), replicas, mappings))
+	settings := util.AdaptIndexBody(fmt.Sprintf(indexConfig, util.HiddenIndexSettings(), util.MetaIndexShards(2), replicas, mappings))
 
 	// index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(indexWithSuffix).Body(settings).Do(context.Background())
@@ -3809,7 +3832,7 @@ func createRecentSearchesIndex(indexWithSuffix, indexConfig string) (*recentDocu
 	}
 
 	// Use fallback method to create the index without the mappings
-	fallbackSettings := util.AdaptIndexBody(fmt.Sprintf(indexConfig, util.HiddenIndexSettings(), replicas, "{}"))
+	fallbackSettings := util.AdaptIndexBody(fmt.Sprintf(indexConfig, util.HiddenIndexSettings(), util.MetaIndexShards(2), replicas, "{}"))
 	_, fallbackErr := util.GetClient7().CreateIndex(indexWithSuffix).Body(fallbackSettings).Do(context.Background())
 	if fallbackErr != nil {
 		return nil, fmt.Errorf("error while creating index named %s: %v", indexWithSuffix, err)

--- a/plugins/analytics/middleware.go
+++ b/plugins/analytics/middleware.go
@@ -530,6 +530,9 @@ type RecordUserSessionConfig struct {
 
 // Records a user session for a particular search request
 func (a *Analytics) recordUserSession(config RecordUserSessionConfig) {
+	if a.es == nil {
+		return
+	}
 	// Don't record for invalid plans
 	if !util.ValidatePlans(validPlans, util.GetFeatureCustomEvents()) {
 		return

--- a/plugins/analytics/middleware_es6.go
+++ b/plugins/analytics/middleware_es6.go
@@ -83,6 +83,10 @@ func (a *Analytics) recordAnalyticsES6(esResponse searchResponseEs6, docID, sear
 		calculateAnalytics(r, &record)
 	}
 
+	if a.es == nil {
+		return
+	}
+
 	err2 := a.es.updateRecord(context.Background(), docID, record)
 	if err2 != nil {
 		return

--- a/plugins/analytics/middleware_es7.go
+++ b/plugins/analytics/middleware_es7.go
@@ -87,6 +87,10 @@ func (a *Analytics) recordAnalyticsES7(esResponse searchResponseEs7, docID, sear
 		calculateAnalytics(r, &record)
 	}
 
+	if a.es == nil {
+		return
+	}
+
 	// TODO: remove
 	//logRaw(record)
 	err2 := a.es.updateRecord(context.Background(), docID, record)

--- a/plugins/applycache/applycache.go
+++ b/plugins/applycache/applycache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/plugins"
 	"github.com/appbaseio/reactivesearch-api/util"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -44,6 +45,7 @@ func Instance() *Cache {
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (c *Cache) InitFunc() error {
 	if !util.ShouldCreateMetaIndex(util.MetaIndexCacheStats) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
 		return nil
 	}
 	indexPrefix := util.MetaIndexName(cacheEsIndex)

--- a/plugins/applycache/applycache.go
+++ b/plugins/applycache/applycache.go
@@ -43,6 +43,9 @@ func Instance() *Cache {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (c *Cache) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexCacheStats) {
+		return nil
+	}
 	indexPrefix := util.MetaIndexName(cacheEsIndex)
 
 	// initialize the dao

--- a/plugins/applycache/middleware.go
+++ b/plugins/applycache/middleware.go
@@ -140,6 +140,7 @@ func applyCachedResponse(h http.HandlerFunc) http.HandlerFunc {
 
 		isCacheHit := false
 		cacheInstance := Instance()
+		trackCacheStats := cacheInstance.rollOver != nil
 
 		if cache.ShouldApplyCache(req, *body) {
 			startTime, err := tracktime.FromTimeTrackerContext(req.Context())
@@ -167,7 +168,9 @@ func applyCachedResponse(h http.HandlerFunc) http.HandlerFunc {
 			// We will consider the cache a hit only when it reaches this phase.
 			if cachedResponse != nil {
 				// Capture the cache as a hit
-				cacheInstance.rollOver.Add(true, cachedResponse.PerformanceSave)
+				if trackCacheStats {
+					cacheInstance.rollOver.Add(true, cachedResponse.PerformanceSave)
+				}
 				isCacheHit = true
 
 				for k, v := range cachedResponse.Headers {
@@ -179,7 +182,7 @@ func applyCachedResponse(h http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// If cache is not hit, count it as a miss
-		if !isCacheHit {
+		if !isCacheHit && trackCacheStats {
 			cacheInstance.rollOver.Add(false, 0)
 		}
 

--- a/plugins/applycache/util.go
+++ b/plugins/applycache/util.go
@@ -72,6 +72,9 @@ func (r *RollOverStat) RollOver() *CacheStatES {
 // The value of performanceSave will be ignored if the cache
 // was not hit.
 func (r *RollOverStat) Add(isHit bool, performanceSave int64) {
+	if r == nil || r.Stat == nil {
+		return
+	}
 	r.mu.Lock()
 
 	r.Stat.CacheRequestCount += 1

--- a/plugins/auth/auth.go
+++ b/plugins/auth/auth.go
@@ -97,57 +97,79 @@ func (a *Auth) InitFunc() error {
 		return err
 	}
 
-	// Create public key index
-	_, err = a.es.createIndex(publicKeyIndex, settings)
-	if err != nil {
-		return err
-	}
+	if util.ShouldCreateMetaIndex(util.MetaIndexPublicKey) {
+		// Create public key index
+		_, err = a.es.createIndex(publicKeyIndex, settings)
+		if err != nil {
+			return err
+		}
 
-	// Populate public key from ES
-	record, err := a.es.getPublicKey(context.Background())
-	if err != nil {
-		jwtRsaPublicKeyLoc := os.Getenv(envJwtRsaPublicKeyLoc)
-		if jwtRsaPublicKeyLoc != "" {
-			// Read file from location
-			var publicKeyBuf []byte
-			publicKeyBuf, err = ioutil.ReadFile(jwtRsaPublicKeyLoc)
-			if err != nil {
-				log.Errorln(logTag, ":unable to read the public key file from environment,", err)
-			}
-			var record = publicKey{}
-			record.PublicKey = string(publicKeyBuf)
-			record.RoleKey = a.jwtRoleKey
-			jwtRsaPublicKey, err := getJWTPublickKey(record)
-			if err != nil {
-				log.Errorln(logTag, ":unable to save public key record from environment,", err)
-			} else {
-				_, err = a.savePublicKey(context.Background(), publicKeyIndex, record)
+		// Populate public key from ES
+		record, err := a.es.getPublicKey(context.Background())
+		if err != nil {
+			jwtRsaPublicKeyLoc := os.Getenv(envJwtRsaPublicKeyLoc)
+			if jwtRsaPublicKeyLoc != "" {
+				// Read file from location
+				var publicKeyBuf []byte
+				publicKeyBuf, err = ioutil.ReadFile(jwtRsaPublicKeyLoc)
+				if err != nil {
+					log.Errorln(logTag, ":unable to read the public key file from environment,", err)
+				}
+				var record = publicKey{}
+				record.PublicKey = string(publicKeyBuf)
+				record.RoleKey = a.jwtRoleKey
+				jwtRsaPublicKey, err := getJWTPublickKey(record)
 				if err != nil {
 					log.Errorln(logTag, ":unable to save public key record from environment,", err)
 				} else {
-					// Update local state
+					_, err = a.savePublicKey(context.Background(), publicKeyIndex, record)
+					if err != nil {
+						log.Errorln(logTag, ":unable to save public key record from environment,", err)
+					} else {
+						// Update local state
+						a.updateLocalPublicKey(jwtRsaPublicKey, record.RoleKey)
+					}
+				}
+			}
+		} else {
+			publicKeyBuf, err := util.DecodeBase64Key(record.PublicKey)
+			if err != nil {
+				log.Errorln(logTag, ":error parsing public key record,", err)
+			}
+			a.jwtRsaPublicKey, err = jwt.ParseRSAPublicKeyFromPEM(publicKeyBuf)
+			if err != nil {
+				log.Errorln(logTag, ":error parsing public key record,", err)
+			}
+			a.jwtRoleKey = record.RoleKey
+		}
+
+		// Set plugin cache sync script
+		s := CacheSyncScript{
+			index: publicKeyIndex,
+			a:     a,
+		}
+		util.AddSyncScript(s)
+	} else {
+		jwtRsaPublicKeyLoc := os.Getenv(envJwtRsaPublicKeyLoc)
+		if jwtRsaPublicKeyLoc != "" {
+			publicKeyBuf, readErr := ioutil.ReadFile(jwtRsaPublicKeyLoc)
+			if readErr != nil {
+				log.Errorln(logTag, ": unable to read the public key file from environment,", readErr)
+			} else {
+				var record = publicKey{}
+				record.PublicKey = string(publicKeyBuf)
+				record.RoleKey = a.jwtRoleKey
+				jwtRsaPublicKey, parseErr := getJWTPublickKey(record)
+				if parseErr != nil {
+					log.Errorln(logTag, ": unable to parse public key from environment,", parseErr)
+				} else {
 					a.updateLocalPublicKey(jwtRsaPublicKey, record.RoleKey)
 				}
 			}
+		} else {
+			log.Infoln(logTag, ": skipping .publickey index (setup profile:", util.GetSetupProfile(), "); set JWT_RSA_PUBLIC_KEY_LOC for JWT auth")
 		}
-	} else {
-		publicKeyBuf, err := util.DecodeBase64Key(record.PublicKey)
-		if err != nil {
-			log.Errorln(logTag, ":error parsing public key record,", err)
-		}
-		a.jwtRsaPublicKey, err = jwt.ParseRSAPublicKeyFromPEM(publicKeyBuf)
-		if err != nil {
-			log.Errorln(logTag, ":error parsing public key record,", err)
-		}
-		a.jwtRoleKey = record.RoleKey
 	}
-
-	// Set plugin cache sync script
-	s := CacheSyncScript{
-		index: publicKeyIndex,
-		a:     a,
-	}
-	util.AddSyncScript(s)
 
 	return nil
 }

--- a/plugins/cache/cache.go
+++ b/plugins/cache/cache.go
@@ -45,6 +45,10 @@ func Instance() *Cache {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (c *Cache) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexCache) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	cacheIndex := os.Getenv(envCacheEsIndex)
 	if cacheIndex == "" {
 		cacheIndex = defaultCacheEsIndex

--- a/plugins/logs/dao.go
+++ b/plugins/logs/dao.go
@@ -44,7 +44,7 @@ func initPlugin(alias, config string) (*elasticsearch, error) {
 
 	replicas := util.GetReplicas()
 
-	settings := fmt.Sprintf(config, alias, util.HiddenIndexSettings(), replicas, LogsMappings)
+	settings := fmt.Sprintf(config, alias, util.HiddenIndexSettings(), util.MetaIndexShards(2), replicas, LogsMappings)
 
 	if util.GetVersion() == 6 {
 		mappings := fmt.Sprintf(`{"_doc": %s}`, LogsMappings)
@@ -179,7 +179,7 @@ func (es *elasticsearch) rolloverIndexJob(alias string) {
 	if shouldRollover {
 		rolloverSvc := util.NewIndicesRolloverService(alias, rolloverConditions).
 			Mappings(mappings)
-		if settings := util.RolloverIndexSettings(2); len(settings) > 0 {
+		if settings := util.RolloverIndexSettings(util.MetaIndexShards(2)); len(settings) > 0 {
 			rolloverSvc = rolloverSvc.Settings(settings)
 		}
 		rolloverService, err := rolloverSvc.Do(ctx)

--- a/plugins/logs/logs.go
+++ b/plugins/logs/logs.go
@@ -28,7 +28,7 @@ const (
 	  },
 	  "settings": {
 		%s
-	    "index.number_of_shards": 2,
+	    "index.number_of_shards": %d,
 	    "index.number_of_replicas": %d
 	  },
 	  "mappings": %s
@@ -79,6 +79,10 @@ func (l *Logs) IsDiffingDisabled() bool {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (l *Logs) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexLogs) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	// Set the value for enableDiffing
 	//
 	// We will read the value from an environment variable

--- a/plugins/nodes/handlers.go
+++ b/plugins/nodes/handlers.go
@@ -17,6 +17,12 @@ func (n *nodes) healthCheckNodes() http.HandlerFunc {
 			Health: "ok",
 		}
 
+		if n.es == nil {
+			responseInBytes, _ := json.Marshal(response)
+			util.WriteBackRaw(w, responseInBytes, http.StatusOK)
+			return
+		}
+
 		// Add the node counts after fetching it from ES
 		activeTenMins, err := n.es.activeNodesInTenMins(req.Context())
 		if err != nil {

--- a/plugins/nodes/nodes.go
+++ b/plugins/nodes/nodes.go
@@ -38,6 +38,10 @@ func (n *nodes) Name() string {
 }
 
 func (n *nodes) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexNodes) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	log.Println(logTag, ": initializing plugin")
 
 	indexName := util.MetaIndexName(defaultNodesIndex)

--- a/plugins/nodes/util.go
+++ b/plugins/nodes/util.go
@@ -52,6 +52,10 @@ func (n *nodes) DeleteOutdated() {
 // - ping job: every 1m
 // - delete job: every 7d
 func (n *nodes) StartAutomatedJobs() {
+	if n.es == nil {
+		return
+	}
+
 	// Start the ping job
 	pingESJob := cron.New()
 	pingESJob.AddFunc("@every 1m", n.PingESWithTime)

--- a/plugins/openai/openai.go
+++ b/plugins/openai/openai.go
@@ -85,6 +85,11 @@ func (r *OpenAI) InitFunc() error {
 	// Initialize the chatGPT session ID map
 	r.sessionMap = SessionInstance()
 
+	if !util.ShouldCreateMetaIndex(util.MetaIndexOpenAI) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
+
 	openAIIndex := os.Getenv(envOpenAIEsIndex)
 	if openAIIndex == "" {
 		openAIIndex = defaultOpenAIEsIndex
@@ -106,15 +111,19 @@ func (r *OpenAI) InitFunc() error {
 	util.AddMigrationScript(migration)
 
 	// Initialize the analytics plugin as well
-	r.analyticsEs, err = initAnalyticsPlugin(util.MetaIndexName(defaultAIAnalyticsIndex), analyticsMapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexAIAnalytics) {
+		r.analyticsEs, err = initAnalyticsPlugin(util.MetaIndexName(defaultAIAnalyticsIndex), analyticsMapping)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Initialize the FAQ index on ES
-	r.faqEs, err = initFAQPluginES(util.MetaIndexName(defaultFAQIndex), FAQMapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexAIFAQs) {
+		r.faqEs, err = initFAQPluginES(util.MetaIndexName(defaultFAQIndex), FAQMapping)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Fetch the settings

--- a/plugins/pipelines/analytics.go
+++ b/plugins/pipelines/analytics.go
@@ -822,7 +822,7 @@ func (es *invocationElasticsearch) rolloverIndexJob(alias string) {
 	if shouldRollover {
 		rolloverSvc := util.NewIndicesRolloverService(alias, rolloverConditions).
 			Mappings(mappings)
-		if settings := util.RolloverIndexSettings(3); len(settings) > 0 {
+		if settings := util.RolloverIndexSettings(util.MetaIndexShards(3)); len(settings) > 0 {
 			rolloverSvc = rolloverSvc.Settings(settings)
 		}
 		rolloverService, err := rolloverSvc.Do(ctx)

--- a/plugins/pipelines/dao.go
+++ b/plugins/pipelines/dao.go
@@ -44,7 +44,7 @@ func initPlugin(pipelinesIndex, mapping string) (*elasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, pipelinesMapping, util.HiddenIndexSettings(), replicas))
+	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, pipelinesMapping, util.HiddenIndexSettings(), util.MetaIndexShards(3), replicas))
 
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(pipelinesIndex).Body(settings).Do(ctx)
@@ -79,7 +79,7 @@ func initInvocationIndex(invocationAlias, _ string) (*invocationElasticsearch, e
 	}
 
 	replicas := util.GetReplicas()
-	settings := util.AdaptIndexBody(fmt.Sprintf(invocationConfig, invocationAlias, util.HiddenIndexSettings(), replicas, pipelineInvocationMapping))
+	settings := util.AdaptIndexBody(fmt.Sprintf(invocationConfig, invocationAlias, util.HiddenIndexSettings(), util.MetaIndexShards(3), replicas, pipelineInvocationMapping))
 
 	// Create the index name to match the name regex for rollover
 	invocationIndex := invocationAlias + `-000001`
@@ -156,7 +156,7 @@ func initLogIndex(logsAlias, mapping string) (*logsElasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, logsAlias, util.HiddenIndexSettings(), replicas, pipelineLogsMapping))
+	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, logsAlias, util.HiddenIndexSettings(), util.MetaIndexShards(3), replicas, pipelineLogsMapping))
 
 	// Create the index name to match the name regex for
 	logsIndex := logsAlias + `-000001`
@@ -227,7 +227,7 @@ func initVarIndex(varIndex, mapping string) (*varElasticsearch, error) {
 	}
 
 	replicas := util.GetReplicas()
-	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, pipelineVarMapping, util.HiddenIndexSettings(), replicas))
+	settings := util.AdaptIndexBody(fmt.Sprintf(mapping, pipelineVarMapping, util.HiddenIndexSettings(), util.MetaIndexShards(3), replicas))
 
 	// Meta index does not exists, create a new one
 	_, err = util.GetClient7().CreateIndex(varIndex).Body(settings).Do(ctx)

--- a/plugins/pipelines/handler.go
+++ b/plugins/pipelines/handler.go
@@ -1077,7 +1077,9 @@ func (pipeline ESPipelineDoc) executePipeline(pipelineExecutionContext PipelineE
 				log.Debug(logTag, ": waiting for bg scripts to complete (if any)")
 				bgScriptWg.Wait()
 				log.Debug(logTag, ": done waiting! Creating invocation record.")
-				Instance().invocationEs.createPipelineInvokeRecord(*pipeline.ID, *pipeline.LiveVersion, stagesInvokedMap.GetStagesMap(), timeTook)
+				if inv := Instance().invocationEs; inv != nil {
+					inv.createPipelineInvokeRecord(*pipeline.ID, *pipeline.LiveVersion, stagesInvokedMap.GetStagesMap(), timeTook)
+				}
 			}(bgScriptWg)
 		}(bgScriptWg)
 	}

--- a/plugins/pipelines/logs.go
+++ b/plugins/pipelines/logs.go
@@ -267,7 +267,7 @@ func (es *logsElasticsearch) rolloverIndexJob(alias string) {
 	if shouldRollover {
 		rolloverSvc := util.NewIndicesRolloverService(alias, rolloverConditions).
 			Mappings(mappings)
-		if settings := util.RolloverIndexSettings(2); len(settings) > 0 {
+		if settings := util.RolloverIndexSettings(util.MetaIndexShards(2)); len(settings) > 0 {
 			rolloverSvc = rolloverSvc.Settings(settings)
 		}
 		rolloverService, err := rolloverSvc.Do(ctx)
@@ -372,15 +372,27 @@ func (route ESPipelineRoutes) initLogsRecorder(h http.HandlerFunc) http.HandlerF
 
 		// If recording logs is disabled, return
 		if route.RecordLogs != nil && !*route.RecordLogs {
+			h(rw, r)
 			return
+		}
+
+		routeCategory := category.Pipelines
+		routeACL := acl.ACL(0)
+		if route.Classify != nil {
+			if route.Classify.Category != nil {
+				routeCategory = *route.Classify.Category
+			}
+			if route.Classify.ACL != nil {
+				routeACL = *route.Classify.ACL
+			}
 		}
 
 		// Create a new pipeline log and store it in the
 		// context with the basic pipeline details
 		pipelineLog := PipelineLog{
 			Route:        route.Path,
-			Category:     route.Classify.Category,
-			ACL:          route.Classify.ACL,
+			Category:     &routeCategory,
+			ACL:          &routeACL,
 			Request:      new(Request),
 			PipelineID:   new(string),
 			Took:         new(int),

--- a/plugins/pipelines/pipelines.go
+++ b/plugins/pipelines/pipelines.go
@@ -21,7 +21,7 @@ const (
 	defaultPipelineVarsIndex          = ".pipeline_vars"
 	typeName                          = "_doc"
 	envPipelinesEsIndexSuffix         = "PIPELINES_ES_INDEX_SUFFIX"
-	mapping                           = `{"mappings": %s, "settings":{ %s "index.number_of_shards": 3, "index.number_of_replicas":%d}}`
+	mapping                           = `{"mappings": %s, "settings":{ %s "index.number_of_shards": %d, "index.number_of_replicas":%d}}`
 	envPipelineLogFilePath            = "PIPELINE_LOG_FILE_PATH"
 	defaultPipelineLogFilePath        = "log/arc/pipeline.json"
 	envPipelineInvocationFilePath     = "PIPELINE_INVOCATION_FILE_PATH"
@@ -38,7 +38,7 @@ const (
 	  },
 	  "settings": {
 		%s
-	    "index.number_of_shards": 3,
+	    "index.number_of_shards": %d,
 	    "index.number_of_replicas": %d
 	  },
 	  "mappings": %s
@@ -52,7 +52,7 @@ const (
 	  },
 	  "settings": {
 		%s
-	    "index.number_of_shards": 3,
+	    "index.number_of_shards": %d,
 	    "index.number_of_replicas": %d
 	  },
 	  "mappings": %s
@@ -123,27 +123,32 @@ func (p *Pipelines) InitFunc() error {
 
 	// initialize the dao
 	var err error
-	p.es, err = initPlugin(indexPrefix, mapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexPipelines) {
+		p.es, err = initPlugin(indexPrefix, mapping)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Initialize the dao for invocation
-	p.invocationEs, err = initInvocationIndex(util.MetaIndexName(defaultPipelineInvocationIndex), mapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexPipelineInvocations) {
+		p.invocationEs, err = initInvocationIndex(util.MetaIndexName(defaultPipelineInvocationIndex), mapping)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Init the logs index
-	p.logEs, err = initLogIndex(util.MetaIndexName(defaultPipelinesLogEsIndex), logsConfig)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexPipelineLogs) {
+		p.logEs, err = initLogIndex(util.MetaIndexName(defaultPipelinesLogEsIndex), logsConfig)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Init the vars index
-	p.varEs, err = initVarIndex(util.MetaIndexName(defaultPipelineVarsIndex), mapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexPipelineVars) {
+		p.varEs, err = initVarIndex(util.MetaIndexName(defaultPipelineVarsIndex), mapping)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Init the validateId to logs session single
@@ -178,32 +183,33 @@ func (p *Pipelines) InitFunc() error {
 		MaxAge:     30, // in days
 	}
 
-	// Add user session mapping changes to migration script
-	util.AddMigrationScript(MappingsMigration{
-		es:        p.es.(*elasticsearch),
-		indexName: indexPrefix,
-	})
-	// sync rules
-	esRules, err := p.es.getPipelines(context.Background())
-	if err != nil {
-		log.Errorln(logTag, ":", "error while retrieving the pipelines:", err)
-		return nil
+	if p.es != nil {
+		util.AddMigrationScript(MappingsMigration{
+			es:        p.es.(*elasticsearch),
+			indexName: indexPrefix,
+		})
 	}
-	SetPipelinesToCache(esRules)
+	if p.es != nil {
+		esRules, err := p.es.getPipelines(context.Background())
+		if err != nil {
+			log.Errorln(logTag, ":", "error while retrieving the pipelines:", err)
+			return nil
+		}
+		SetPipelinesToCache(esRules)
+	}
 
-	// Sync pipeline vars
-	pipelineVars, err := p.varEs.getVars(context.Background())
-	if err != nil {
-		log.Errorln(logTag, ": error while retrieving the pipeline variables, ", err)
-		return nil
+	if p.varEs != nil {
+		pipelineVars, err := p.varEs.getVars(context.Background())
+		if err != nil {
+			log.Errorln(logTag, ": error while retrieving the pipeline variables, ", err)
+			return nil
+		}
+		SetVars(pipelineVars)
 	}
-	SetVars(pipelineVars)
 
-	// Set plugin cache sync script
-	s := CacheSyncScript{
-		index: indexPrefix,
+	if p.es != nil {
+		util.AddSyncScript(CacheSyncScript{index: indexPrefix})
 	}
-	util.AddSyncScript(s)
 
 	// generate pipeline schema
 	schema, err := GetPipelineSchema()
@@ -214,20 +220,20 @@ func (p *Pipelines) InitFunc() error {
 	// set schema
 	p.pipelineSchema = schema
 
-	// Initiate the logs rollover cronjob
-	pipelineLogsIndex := util.MetaIndexName(defaultPipelinesLogEsIndex)
-	pipelineInvocationsIndex := util.MetaIndexName(defaultPipelineInvocationIndex)
-	cronjob := cron.New()
-	cronjob.AddFunc("@midnight", func() { p.logEs.rolloverIndexJob(pipelineLogsIndex) })
-	// in addition, run every hour, keeping original midnight job as well
-	cronjob.AddFunc("@hourly", func() { p.logEs.rolloverIndexJob(pipelineLogsIndex) })
-
-	// Initiate the invocations rollover cronjob
-	cronjob.AddFunc("@midnight", func() { p.invocationEs.rolloverIndexJob(pipelineInvocationsIndex) })
-	// in addition, run every hour, keeping original midnight job as well
-	cronjob.AddFunc("@hourly", func() { p.invocationEs.rolloverIndexJob(pipelineInvocationsIndex) })
-
-	cronjob.Start()
+	if p.logEs != nil || p.invocationEs != nil {
+		pipelineLogsIndex := util.MetaIndexName(defaultPipelinesLogEsIndex)
+		pipelineInvocationsIndex := util.MetaIndexName(defaultPipelineInvocationIndex)
+		cronjob := cron.New()
+		if p.logEs != nil {
+			cronjob.AddFunc("@midnight", func() { p.logEs.rolloverIndexJob(pipelineLogsIndex) })
+			cronjob.AddFunc("@hourly", func() { p.logEs.rolloverIndexJob(pipelineLogsIndex) })
+		}
+		if p.invocationEs != nil {
+			cronjob.AddFunc("@midnight", func() { p.invocationEs.rolloverIndexJob(pipelineInvocationsIndex) })
+			cronjob.AddFunc("@hourly", func() { p.invocationEs.rolloverIndexJob(pipelineInvocationsIndex) })
+		}
+		cronjob.Start()
+	}
 
 	return nil
 }

--- a/plugins/rules/rules.go
+++ b/plugins/rules/rules.go
@@ -65,30 +65,27 @@ func (r *Rules) InitFunc() error {
 	}
 	indexPrefix = util.MetaIndexName(indexPrefix)
 
-	// initialize the dao
-	var err error
-	r.es, err = initPlugin(indexPrefix, mapping)
-	if err != nil {
-		return err
+	var esRules []ESRuleDoc
+	if util.ShouldCreateMetaIndex(util.MetaIndexRules) {
+		var err error
+		r.es, err = initPlugin(indexPrefix, mapping)
+		if err != nil {
+			return err
+		}
+		util.AddMigrationScript(MappingsMigration{
+			es:        r.es.(*elasticsearch),
+			indexName: indexPrefix,
+		})
+		esRules, err = r.es.getRules(context.Background())
+		if err != nil {
+			log.Errorln(logTag, ":", "error while retrieving the rules:", err)
+			return nil
+		}
+		SetRulesToCache(esRules)
+		util.AddSyncScript(CacheSyncScript{index: indexPrefix})
+	} else {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
 	}
-	// Add user session mapping changes to migration script
-	util.AddMigrationScript(MappingsMigration{
-		es:        r.es.(*elasticsearch),
-		indexName: indexPrefix,
-	})
-	// sync rules
-	esRules, err := r.es.getRules(context.Background())
-	if err != nil {
-		log.Errorln(logTag, ":", "error while retrieving the rules:", err)
-		return nil
-	}
-	SetRulesToCache(esRules)
-
-	// Set plugin cache sync script
-	s := CacheSyncScript{
-		index: indexPrefix,
-	}
-	util.AddSyncScript(s)
 
 	// instantiate a new JavaScript VM
 	r.iso = v8go.NewIsolate()
@@ -117,7 +114,9 @@ func (r *Rules) InitFunc() error {
 	cronjob.Start()
 
 	// Start the cron rules
-	r.initCronRules(esRules)
+	if r.es != nil {
+		r.initCronRules(esRules)
+	}
 
 	return nil
 }

--- a/plugins/searchgrader/searchgrader.go
+++ b/plugins/searchgrader/searchgrader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/plugins"
 	"github.com/appbaseio/reactivesearch-api/util"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -43,6 +44,10 @@ func (s *SearchGrader) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (s *SearchGrader) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexSearchGrader) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	// fetch the required env vars
 	searchgraderIndex := os.Getenv(envSearchgraderEsIndex)
 	if searchgraderIndex == "" {

--- a/plugins/searchrelevancy/searchrelevancy.go
+++ b/plugins/searchrelevancy/searchrelevancy.go
@@ -47,6 +47,11 @@ func (a *SearchRelevancy) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (a *SearchRelevancy) InitFunc() error {
+	a.validate = validator.New()
+	if !util.ShouldCreateMetaIndex(util.MetaIndexSearchRelevancy) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	// fetch the required env vars
 	searchRelevancyIndex := os.Getenv(envSearchRelevancyEsIndex)
 	if searchRelevancyIndex == "" {
@@ -67,9 +72,6 @@ func (a *SearchRelevancy) InitFunc() error {
 		return nil
 	}
 	SetSearchRelevancySettingsCache(relevancySettings)
-
-	// initialize validator
-	a.validate = validator.New()
 
 	// Set plugin cache sync script
 	s := CacheSyncScript{

--- a/plugins/storedquery/storedquery.go
+++ b/plugins/storedquery/storedquery.go
@@ -45,6 +45,10 @@ func (s *StoredQuery) Name() string {
 // InitFunc initializes the dao, i.e. elasticsearch client, and should be executed
 // only once in the lifetime of the plugin.
 func (s *StoredQuery) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexStoredQuery) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	indexPrefix := os.Getenv(envStoredQueryEsIndex)
 	if indexPrefix == "" {
 		indexPrefix = defaultStoredQueryEsIndex

--- a/plugins/suggestions/suggestions.go
+++ b/plugins/suggestions/suggestions.go
@@ -236,6 +236,10 @@ func (rx *suggestions) Name() string {
 }
 
 func (r *suggestions) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexSuggestionsPrefs) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	// Create suggestions preferences index if not exists
 	indexPreferencesSuffix := os.Getenv(envSuggestionsPreferencesEsIndex)
 	if indexPreferencesSuffix == "" {

--- a/plugins/sync/sync.go
+++ b/plugins/sync/sync.go
@@ -44,6 +44,10 @@ func (p *Sync) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (p *Sync) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexSyncPreferences) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 
 	// Create suggestions preferences index if not exists
 	indexName := os.Getenv(envSyncPreferencesEsIndex)

--- a/plugins/synonyms/synonyms.go
+++ b/plugins/synonyms/synonyms.go
@@ -9,6 +9,7 @@ import (
 	"github.com/appbaseio/reactivesearch-api/middleware"
 	"github.com/appbaseio/reactivesearch-api/util"
 	"github.com/go-playground/validator/v10"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -46,6 +47,11 @@ func (s *Synonyms) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (s *Synonyms) InitFunc() error {
+	s.validate = validator.New()
+	if !util.ShouldCreateMetaIndex(util.MetaIndexSynonyms) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
 	// fetch the required env vars
 	synonymsIndex := os.Getenv(synonymsEsIndex)
 	if synonymsIndex == "" {
@@ -60,12 +66,9 @@ func (s *Synonyms) InitFunc() error {
 		return err
 	}
 
-	// initialize validator
-	s.validate = validator.New()
 	return nil
 }
 
-// Routes returns the synonyms routes that the plugin serves.
 func (s *Synonyms) Routes() []plugins.Route {
 	return s.routes()
 }

--- a/plugins/uibuilder/uibuilder.go
+++ b/plugins/uibuilder/uibuilder.go
@@ -61,6 +61,13 @@ func (e *UIBuilder) Name() string {
 // InitFunc is a part of Plugin interface that gets executed only once, and initializes
 // the dao, i.e. elasticsearch before the plugin is operational.
 func (e *UIBuilder) InitFunc() error {
+	if !util.ShouldCreateMetaIndex(util.MetaIndexUIBuilderPreferences) &&
+		!util.ShouldCreateMetaIndex(util.MetaIndexSearchBox) &&
+		!util.ShouldCreateMetaIndex(util.MetaIndexFeaturedSuggestions) {
+		log.Infoln(logTag, ": skipping ES index creation (setup profile:", util.GetSetupProfile(), ")")
+		return nil
+	}
+
 	preferencesIndex := os.Getenv(envUIBuilderPreferencesIndex)
 	if preferencesIndex == "" {
 		preferencesIndex = defaultUIBuilderPreferencesIndex
@@ -72,9 +79,11 @@ func (e *UIBuilder) InitFunc() error {
 	}
 	searchboxIndex = util.MetaIndexName(searchboxIndex)
 	var err error
-	e.esFeaturedSuggestions, _, err = createSearchBoxIndex(searchboxIndex, mapping)
-	if err != nil {
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexSearchBox) {
+		e.esFeaturedSuggestions, _, err = createSearchBoxIndex(searchboxIndex, mapping)
+		if err != nil {
+			return err
+		}
 	}
 	// Create separate index for denormalized featured suggestions
 	featuredSuggestionsIndex := os.Getenv(envFeaturedSuggestionsIndex)
@@ -82,54 +91,56 @@ func (e *UIBuilder) InitFunc() error {
 		featuredSuggestionsIndex = defaultFeaturedSuggestionsIndex
 	}
 	featuredSuggestionsIndex = util.MetaIndexName(featuredSuggestionsIndex)
-	_, featuredSuggestionsIndexExists, err := createSearchBoxIndex(featuredSuggestionsIndex, featuredSuggestionsMapping)
-	if err != nil {
-		return err
-	}
-	e.featuredSuggestionsConfig = FeaturedSuggestionsConfig{
-		esIndex: featuredSuggestionsIndex,
+	var featuredSuggestionsIndexExists bool
+	if util.ShouldCreateMetaIndex(util.MetaIndexFeaturedSuggestions) {
+		_, featuredSuggestionsIndexExists, err = createSearchBoxIndex(featuredSuggestionsIndex, featuredSuggestionsMapping)
+		if err != nil {
+			return err
+		}
+		e.featuredSuggestionsConfig = FeaturedSuggestionsConfig{
+			esIndex: featuredSuggestionsIndex,
+		}
 	}
 
 	// initialize the dao
-	e.es, err = initPlugin(preferencesIndex, mapping)
-	if err != nil {
-		log.Errorln(logTag, ":", err)
-		return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexUIBuilderPreferences) {
+		e.es, err = initPlugin(preferencesIndex, mapping)
+		if err != nil {
+			log.Errorln(logTag, ":", err)
+			return err
+		}
 	}
 	oldPreferenceIndex := os.Getenv(envEcommPreferencesIndex)
 	if oldPreferenceIndex == "" {
 		oldPreferenceIndex = defaultEcommPreferencesIndex
 	}
-	// Add suggestions preferences migration script
-	m := UIBuilderPreferencesMigration{
-		newIndex: preferencesIndex,
-		oldIndex: oldPreferenceIndex,
+	if util.ShouldCreateMetaIndex(util.MetaIndexUIBuilderPreferences) {
+		util.AddMigrationScript(UIBuilderPreferencesMigration{
+			newIndex: preferencesIndex,
+			oldIndex: oldPreferenceIndex,
+		})
 	}
-	util.AddMigrationScript(m)
 
-	// sync searchbox preferences cache
-	searchboxPreferencesResponse, err := util.GetClient7().
-		Search(searchboxIndex).
-		Size(10000).
-		Do(context.Background())
-	if err != nil {
-		return err
-	}
-	if searchboxPreferencesResponse != nil {
-		// Only sync featured suggestions to ES if the index was just created
-		// (if it already existed, data is already there)
-		syncToES := !featuredSuggestionsIndexExists
-		err := e.featuredSuggestionsConfig.setFeaturedSuggestionsFromESResponse(searchboxPreferencesResponse, searchboxIndex, syncToES)
-		if err != nil {
-			return err
+	if util.ShouldCreateMetaIndex(util.MetaIndexSearchBox) {
+		searchboxPreferencesResponse, searchErr := util.GetClient7().
+			Search(searchboxIndex).
+			Size(10000).
+			Do(context.Background())
+		if searchErr != nil {
+			return searchErr
 		}
+		if searchboxPreferencesResponse != nil && util.ShouldCreateMetaIndex(util.MetaIndexFeaturedSuggestions) {
+			syncToES := !featuredSuggestionsIndexExists
+			err := e.featuredSuggestionsConfig.setFeaturedSuggestionsFromESResponse(searchboxPreferencesResponse, searchboxIndex, syncToES)
+			if err != nil {
+				return err
+			}
+		}
+		util.AddSyncScript(FeaturedSuggestionsCacheSyncScript{
+			index:                     searchboxIndex,
+			featuredSuggestionsConfig: e.featuredSuggestionsConfig,
+		})
 	}
-	// Set featured suggestions cache sync script
-	f := FeaturedSuggestionsCacheSyncScript{
-		index:                     searchboxIndex,
-		featuredSuggestionsConfig: e.featuredSuggestionsConfig,
-	}
-	util.AddSyncScript(f)
 	return nil
 }
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+# Render Blueprint — one-click deploy for ReactiveSearch API.
+#
+# Pair with Aiven free OpenSearch: https://aiven.io/free-opensearch
+# Set ES_CLUSTER_URL to your Aiven service URI (credentials in the URL).
+
+services:
+  - type: web
+    name: reactivesearch-api
+    runtime: docker
+    plan: free
+    region: oregon
+    healthCheckPath: /arc/health
+    autoDeployTrigger: off
+    envVars:
+      - key: ES_CLUSTER_URL
+        sync: false
+      - key: RS_SETUP_PROFILE
+        value: minimal
+      - key: USERNAME
+        value: rs-demo
+      - key: PASSWORD
+        value: rs-password

--- a/scripts/smoke-minimal.sh
+++ b/scripts/smoke-minimal.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Smoke tests for RS_SETUP_PROFILE=minimal (auth, pipelines, pipeline vars, ES proxy).
+#
+# Usage:
+#   ./scripts/smoke-minimal.sh
+#   RS_URL=http://localhost:8000 RS_USER=foo RS_PASSWORD=bar ./scripts/smoke-minimal.sh
+
+set -u
+
+RS_URL="${RS_URL:-http://localhost:8000}"
+RS_USER="${RS_USER:-foo}"
+RS_PASSWORD="${RS_PASSWORD:-bar}"
+AUTH="${RS_USER}:${RS_PASSWORD}"
+PIPELINE_ID="${PIPELINE_ID:-minimal-smoke-test}"
+PIPELINE_PATH="/api/${PIPELINE_ID}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red() { printf '\033[31m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+pass() { PASS=$((PASS + 1)); green "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); red "FAIL: $*"; }
+skip() { SKIP=$((SKIP + 1)); yellow "SKIP: $*"; }
+
+http_code() {
+	curl -s -o /dev/null -w "%{http_code}" "$@"
+}
+
+http_body() {
+	curl -s "$@"
+}
+
+echo "=== ReactiveSearch minimal profile smoke test ==="
+echo "RS_URL=${RS_URL}  user=${RS_USER}"
+echo
+
+# --- 1. Health (no auth) ---
+code="$(http_code "${RS_URL}/arc/health")"
+if [ "$code" = "200" ]; then
+	pass "GET /arc/health -> ${code}"
+else
+	fail "GET /arc/health -> ${code} (expected 200)"
+fi
+
+arc_health="$(http_body "${RS_URL}/arc/_health")"
+if echo "$arc_health" | grep -q '"health":"ok"'; then
+	pass "GET /arc/_health reports ok"
+else
+	fail "GET /arc/_health unexpected body: ${arc_health}"
+fi
+
+# --- 2. Auth ---
+code="$(http_code "${RS_URL}/_users")"
+if [ "$code" = "401" ]; then
+	pass "GET /_users without auth -> 401"
+else
+	fail "GET /_users without auth -> ${code} (expected 401)"
+fi
+
+users_body="$(http_body -u "$AUTH" "${RS_URL}/_users")"
+if echo "$users_body" | grep -q '"foo"'; then
+	pass "GET /_users with auth lists user foo"
+else
+	fail "GET /_users with auth missing foo: ${users_body}"
+fi
+
+# --- 3. Meta indices (exactly 4 dot indices from minimal profile) ---
+meta_indices="$(http_body -u "$AUTH" "${RS_URL}/_cat/indices/.users,.permissions,.pipelines,.pipeline_vars?h=index")"
+for idx in .users .permissions .pipelines .pipeline_vars; do
+	if echo "$meta_indices" | grep -qx "$idx"; then
+		pass "meta index exists: ${idx}"
+	else
+		fail "meta index missing: ${idx}"
+	fi
+done
+
+# --- 4. Pipelines ---
+pipeline_json="$(cat <<EOF
+{
+  "id": "${PIPELINE_ID}",
+  "enabled": true,
+  "routes": [{"path": "${PIPELINE_PATH}", "method": "GET"}],
+  "stages": [{
+    "id": "respond",
+    "script": "function handleRequest() { return { response: { body: JSON.stringify({ ok: true, pipeline: '${PIPELINE_ID}' }), code: 200 } }; }"
+  }]
+}
+EOF
+)"
+pipeline_file="$(mktemp /tmp/rs-smoke-pipeline.XXXXXX.json)"
+printf '%s' "$pipeline_json" > "$pipeline_file"
+
+existing="$(http_body -u "$AUTH" "${RS_URL}/_pipeline/${PIPELINE_ID}" 2>/dev/null || true)"
+if echo "$existing" | grep -q "\"id\":\"${PIPELINE_ID}\"" || echo "$existing" | grep -q "\"id\": \"${PIPELINE_ID}\""; then
+	skip "pipeline ${PIPELINE_ID} already exists"
+	rm -f "$pipeline_file"
+else
+	create_code="$(curl -s -o /tmp/rs-smoke-pipeline-create.json -w "%{http_code}" -u "$AUTH" \
+		-X POST "${RS_URL}/_pipeline" \
+		-F "pipeline=@${pipeline_file};filename=pipeline.json")"
+	rm -f "$pipeline_file"
+	if [ "$create_code" = "201" ] || [ "$create_code" = "200" ]; then
+		pass "POST /_pipeline -> ${create_code}"
+	else
+		fail "POST /_pipeline -> ${create_code}: $(cat /tmp/rs-smoke-pipeline-create.json 2>/dev/null)"
+	fi
+fi
+
+invoke_body="$(http_body -u "$AUTH" "${RS_URL}${PIPELINE_PATH}")"
+if echo "$invoke_body" | grep -q '"ok":true'; then
+	pass "GET ${PIPELINE_PATH} returns ok"
+else
+	fail "GET ${PIPELINE_PATH} unexpected: ${invoke_body}"
+fi
+
+# --- 5. Pipeline env vars ---
+env_key="SMOKE_GREETING_$(date +%s)"
+env_body="$(cat <<EOF
+{"label":"Smoke test","key":"${env_key}","value":"hello"}
+EOF
+)"
+env_code="$(curl -s -o /tmp/rs-smoke-env.json -w "%{http_code}" -u "$AUTH" \
+	-X POST "${RS_URL}/_pipelines/env" \
+	-H 'Content-Type: application/json' \
+	-d "$env_body")"
+if [ "$env_code" = "200" ] || [ "$env_code" = "201" ]; then
+	pass "POST /_pipelines/env -> ${env_code}"
+else
+	fail "POST /_pipelines/env -> ${env_code}: $(cat /tmp/rs-smoke-env.json 2>/dev/null)"
+fi
+
+envs_body="$(http_body -u "$AUTH" "${RS_URL}/_pipelines/envs")"
+if echo "$envs_body" | grep -q "$env_key"; then
+	pass "GET /_pipelines/envs contains ${env_key}"
+else
+	fail "GET /_pipelines/envs missing ${env_key}: ${envs_body}"
+fi
+
+# --- 6. ES proxy ---
+cluster_code="$(http_code -u "$AUTH" "${RS_URL}/_cluster/health")"
+if [ "$cluster_code" = "200" ]; then
+	pass "GET /_cluster/health -> 200"
+else
+	fail "GET /_cluster/health -> ${cluster_code}"
+fi
+
+sample_index="$(http_body -u "$AUTH" "${RS_URL}/_cat/indices?h=index" | grep -v '^\.' | grep -v '^$' | head -1 || true)"
+if [ -n "$sample_index" ]; then
+	search_code="$(curl -s -o /tmp/rs-smoke-search.json -w "%{http_code}" -u "$AUTH" \
+		-X POST "${RS_URL}/${sample_index}/_search" \
+		-H 'Content-Type: application/json' \
+		-d '{"query":{"match_all":{}},"size":1}')"
+	if [ "$search_code" = "200" ]; then
+		pass "POST /${sample_index}/_search -> 200"
+	else
+		fail "POST /${sample_index}/_search -> ${search_code}"
+	fi
+else
+	skip "no user index found for _search test"
+fi
+
+echo
+echo "=== Summary: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ==="
+if [ "$FAIL" -gt 0 ]; then
+	exit 1
+fi
+exit 0

--- a/util/setup_profile.go
+++ b/util/setup_profile.go
@@ -1,0 +1,130 @@
+package util
+
+import (
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const envSetupProfile = "RS_SETUP_PROFILE"
+
+// SetupProfile controls which meta (system) Elasticsearch indices are created
+// at startup. Defaults to full (current behavior) when unset.
+type SetupProfile string
+
+const (
+	SetupProfileFull     SetupProfile = "full"
+	SetupProfileStandard SetupProfile = "standard"
+	SetupProfileMinimal  SetupProfile = "minimal"
+)
+
+// Meta index keys used by ShouldCreateMetaIndex. Each key maps to the minimum
+// setup profile required to create that index.
+const (
+	MetaIndexUsers                = "users"
+	MetaIndexPermissions          = "permissions"
+	MetaIndexPipelines            = "pipelines"
+	MetaIndexPipelineVars         = "pipeline_vars"
+	MetaIndexSynonyms             = "synonyms"
+	MetaIndexSearchRelevancy      = "searchrelevancy"
+	MetaIndexLogs                 = "logs"
+	MetaIndexPipelineLogs         = "pipeline_logs"
+	MetaIndexPipelineInvocations  = "pipeline_invocations"
+	MetaIndexAnalytics            = "analytics"
+	MetaIndexUserSessions         = "user_sessions"
+	MetaIndexAnalyticsPreferences = "analytics_preferences"
+	MetaIndexPublicKey            = "publickey"
+	MetaIndexAnalyticsInsights    = "actionableinsights"
+	MetaIndexSavedSearches        = "saved_searches"
+	MetaIndexFavorites            = "favorites"
+	MetaIndexRecentDocuments      = "documents"
+	MetaIndexNodes                = "nodes"
+	MetaIndexOpenAI               = "openai"
+	MetaIndexAIAnalytics          = "ai_analytics"
+	MetaIndexAIFAQs               = "ai_faqs"
+	MetaIndexSearchGrader         = "searchgrader"
+	MetaIndexSyncPreferences      = "sync_preferences"
+	MetaIndexUIBuilderPreferences = "uibuilder_preferences"
+	MetaIndexSearchBox            = "searchbox"
+	MetaIndexFeaturedSuggestions  = "featured_suggestions"
+	MetaIndexRules                = "rules"
+	MetaIndexCache                = "cache"
+	MetaIndexSuggestionsPrefs     = "suggestions_preferences"
+	MetaIndexStoredQuery          = "storedquery"
+	MetaIndexCacheStats           = "cache_stats"
+)
+
+var metaIndexMinProfile = map[string]SetupProfile{
+	MetaIndexUsers:                SetupProfileMinimal,
+	MetaIndexPermissions:          SetupProfileMinimal,
+	MetaIndexPipelines:            SetupProfileMinimal,
+	MetaIndexPipelineVars:         SetupProfileMinimal,
+	MetaIndexSynonyms:             SetupProfileStandard,
+	MetaIndexSearchRelevancy:      SetupProfileStandard,
+	MetaIndexLogs:                 SetupProfileStandard,
+	MetaIndexPipelineLogs:         SetupProfileStandard,
+	MetaIndexPipelineInvocations:  SetupProfileStandard,
+	MetaIndexAnalytics:            SetupProfileStandard,
+	MetaIndexUserSessions:         SetupProfileStandard,
+	MetaIndexAnalyticsPreferences: SetupProfileStandard,
+}
+
+// GetSetupProfile returns the active setup profile from RS_SETUP_PROFILE.
+// Unset or unknown values default to full for backward compatibility.
+func GetSetupProfile() SetupProfile {
+	raw := strings.TrimSpace(strings.ToLower(os.Getenv(envSetupProfile)))
+	switch SetupProfile(raw) {
+	case SetupProfileMinimal, SetupProfileStandard, SetupProfileFull:
+		return SetupProfile(raw)
+	case "":
+		return SetupProfileFull
+	default:
+		log.Warnln("unknown RS_SETUP_PROFILE value, using full:", raw)
+		return SetupProfileFull
+	}
+}
+
+func profileRank(p SetupProfile) int {
+	switch p {
+	case SetupProfileMinimal:
+		return 1
+	case SetupProfileStandard:
+		return 2
+	case SetupProfileFull:
+		return 3
+	default:
+		return 3
+	}
+}
+
+// ShouldCreateMetaIndex reports whether the given meta index should be created
+// for the active setup profile.
+func ShouldCreateMetaIndex(key string) bool {
+	minProfile, ok := metaIndexMinProfile[key]
+	if !ok {
+		return profileRank(GetSetupProfile()) >= profileRank(SetupProfileFull)
+	}
+	return profileRank(GetSetupProfile()) >= profileRank(minProfile)
+}
+
+// MetaIndexShards returns the number of primary shards to use for a meta index.
+// Minimal and standard profiles always use 1; full uses the plugin default.
+func MetaIndexShards(defaultShards int) int {
+	if GetSetupProfile() == SetupProfileFull {
+		return defaultShards
+	}
+	return 1
+}
+
+// IsAnalyticsPluginEnabled reports whether any analytics meta index is enabled
+// for the active setup profile.
+func IsAnalyticsPluginEnabled() bool {
+	return ShouldCreateMetaIndex(MetaIndexAnalytics) ||
+		ShouldCreateMetaIndex(MetaIndexUserSessions) ||
+		ShouldCreateMetaIndex(MetaIndexAnalyticsPreferences) ||
+		ShouldCreateMetaIndex(MetaIndexAnalyticsInsights) ||
+		ShouldCreateMetaIndex(MetaIndexSavedSearches) ||
+		ShouldCreateMetaIndex(MetaIndexFavorites) ||
+		ShouldCreateMetaIndex(MetaIndexRecentDocuments)
+}

--- a/util/setup_profile_test.go
+++ b/util/setup_profile_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSetupProfile(t *testing.T) {
+	Convey("Setup profile", t, func() {
+		defer os.Unsetenv(envSetupProfile)
+
+		Convey("defaults to full when unset", func() {
+			So(GetSetupProfile(), ShouldEqual, SetupProfileFull)
+		})
+
+		Convey("minimal creates only core indexes", func() {
+			os.Setenv(envSetupProfile, "minimal")
+			So(ShouldCreateMetaIndex(MetaIndexUsers), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexPipelines), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexPipelineVars), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexPublicKey), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexLogs), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexAnalytics), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexRules), ShouldBeFalse)
+		})
+
+		Convey("standard adds observability indexes but not full-only", func() {
+			os.Setenv(envSetupProfile, "standard")
+			So(ShouldCreateMetaIndex(MetaIndexSynonyms), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexAnalytics), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexAnalyticsInsights), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexRecentDocuments), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexRules), ShouldBeFalse)
+			So(ShouldCreateMetaIndex(MetaIndexCache), ShouldBeFalse)
+		})
+
+		Convey("full creates everything", func() {
+			os.Setenv(envSetupProfile, "full")
+			So(ShouldCreateMetaIndex(MetaIndexRules), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexRecentDocuments), ShouldBeTrue)
+			So(ShouldCreateMetaIndex(MetaIndexPublicKey), ShouldBeTrue)
+		})
+
+		Convey("MetaIndexShards uses 1 outside full profile", func() {
+			os.Setenv(envSetupProfile, "standard")
+			So(MetaIndexShards(3), ShouldEqual, 1)
+			os.Setenv(envSetupProfile, "full")
+			So(MetaIndexShards(3), ShouldEqual, 3)
+		})
+	})
+}


### PR DESCRIPTION
#### What does this do / why do we need it?

- Add `RS_SETUP_PROFILE` (`minimal` / `standard` / `full`) to gate meta-index creation, shard counts, and optional plugins for lean deployments against external Elasticsearch/OpenSearch clusters.
- **Minimal** creates 4 meta indices (`.users`, `.permissions`, `.pipelines`, `.pipeline_vars`); **standard** adds core analytics/ops indices at 1 shard each; **full** preserves current behavior.
- Include `config/minimal.env.example`, `scripts/smoke-minimal.sh`, and nil-safe fixes for nodes cron/health and pipeline invocation when optional indices are skipped.
- Bump version to **9.4.0** (`Makefile`, `Dockerfile`).

#### What should your reviewer look out for in this PR?

- [x] `go test ./util/...` — setup profile unit tests
- [x] `go run main.go --env=config/minimal.env --log=info` — server starts with minimal profile
- [x] `./scripts/smoke-minimal.sh` — 13 passed, 0 failed (auth, 4 meta indices, pipelines, env vars, ES proxy)
- [x] CI tests pass on PR
- [ ] After merge: publish `9.4.0` release / workflow_dispatch Docker image for demo deployment

#### Which issue(s) does this PR fix?

#### If this PR affects any API reference documentation, please share the updated endpoint references

<!--

- [ ] I've updated the doc.

Doc link shared here - <Updated API Reference Doc link>

-->

<!--

fixes #
fixes #

-->
